### PR TITLE
Leading zero count benchmark

### DIFF
--- a/HdrHistogram.Benchmarking/HdrHistogram.Benchmarking.csproj
+++ b/HdrHistogram.Benchmarking/HdrHistogram.Benchmarking.csproj
@@ -6,12 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.6" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.8" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows">
-      <Version>0.10.6</Version>
+      <Version>0.10.8</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/HdrHistogram.Benchmarking/LeadingZeroCount/BBarry32BitIfShiftLookupWith64BitShiftBranch.cs
+++ b/HdrHistogram.Benchmarking/LeadingZeroCount/BBarry32BitIfShiftLookupWith64BitShiftBranch.cs
@@ -1,0 +1,73 @@
+using System;
+
+namespace HdrHistogram.Benchmarking.LeadingZeroCount
+{
+    /// <summary>
+    /// Contributed from @BBarry at https://github.com/HdrHistogram/HdrHistogram.NET/issues/42
+    /// This variation perfoms very well. Similar profile to the "Current Impl".
+    /// Faster on LegacyJIT/CLR, but much slower on RyuJIT (CLR & Core)
+    /// </summary>
+    public static class BBarry32BitIfShiftLookupWith64BitShiftBranch
+    {
+        private static readonly int[] Lookup;
+
+        static BBarry32BitIfShiftLookupWith64BitShiftBranch()
+        {
+            Lookup = new int[256];
+            for (int i = 1; i < 256; ++i)
+            {
+                Lookup[i] = (int)(Math.Log(i) / Math.Log(2));
+            }
+        }
+        public static int GetLeadingZeroCount(long value)
+        {
+            //TODO: Test this with just < instead of <=? i.e. const of int.Max+1;
+            if (value <= int.MaxValue)
+                return 63 - Log2((int)value);
+            if (value <= uint.MaxValue)
+                return 62 - Log2((int)(value >> 1));
+            return 31 - Log2((int)(value >> 32));
+        }
+
+        private static int Log2(int i)
+        {
+            if (i >= 0x1000000) { return Lookup[i >> 24] + 24; }
+            if (i >= 0x10000) { return Lookup[i >> 16] + 16; }
+            if (i >= 0x100) { return Lookup[i >> 8] + 8; }
+            return Lookup[i];
+        }
+    }
+
+    /// <summary>
+    /// Contributed from @BBarry at https://github.com/HdrHistogram/HdrHistogram.NET/issues/42
+    /// This variation perfoms very well. Similar profile to the "Current Impl".
+    /// Faster on LegacyJIT/CLR, but much slower on RyuJIT (CLR & Core)
+    /// </summary>
+    public static class BBarry32BitIfShiftLookupWith64BitShiftBranch_2
+    {
+        private static readonly int[] Lookup;
+        private const long IntOverflow = int.MaxValue + 1L;
+        static BBarry32BitIfShiftLookupWith64BitShiftBranch_2()
+        {
+            Lookup = new int[256];
+            for (int i = 1; i < 256; ++i)
+            {
+                Lookup[i] = (int)(Math.Log(i) / Math.Log(2));
+            }
+        }
+        public static int GetLeadingZeroCount(long value)
+        {
+            if (value < IntOverflow)
+                return 63 - Log2((uint)value);
+            return 32 - Log2((uint)(value >> 31));
+        }
+
+        private static int Log2(uint i)
+        {
+            if (i >= 0x1000000) { return Lookup[i >> 24] + 24; }
+            if (i >= 0x10000) { return Lookup[i >> 16] + 16; }
+            if (i >= 0x100) { return Lookup[i >> 8] + 8; }
+            return Lookup[i];
+        }
+    }
+}

--- a/HdrHistogram.Benchmarking/LeadingZeroCount/BBarryIfShiftLookup.cs
+++ b/HdrHistogram.Benchmarking/LeadingZeroCount/BBarryIfShiftLookup.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace HdrHistogram.Benchmarking.LeadingZeroCount
+{
+    /// <summary>
+    /// Contributed from @BBarry at https://github.com/HdrHistogram/HdrHistogram.NET/issues/42
+    /// This variation inlines all the shifts.
+    /// It performs on par on LegacyJIT/CLR but significantly slower on RyuJIT.
+    /// I assume it is because 7 branches vs the 4 above.
+    /// </summary>
+    internal static class BBarryIfShiftLookup
+    {
+        private static readonly int[] Lookup;
+
+        static BBarryIfShiftLookup()
+        {
+            Lookup = new int[256];
+            for (int i = 1; i < 256; ++i)
+            {
+                Lookup[i] = (int)(Math.Log(i) / Math.Log(2));
+            }
+        }
+
+        public static int GetLeadingZeroCount(long value)
+        {
+            if (value >= 0x100000000000000) { return 7 - Lookup[value >> 56]; }
+            if (value >= 0x1000000000000) { return 15 - Lookup[value >> 48]; }
+            if (value >= 0x10000000000) { return 23 - Lookup[value >> 40]; }
+            if (value >= 0x100000000) { return 31 - Lookup[value >> 32]; }
+            if (value >= 0x1000000) { return 39 - Lookup[value >> 24]; }
+            if (value >= 0x10000) { return 47 - Lookup[value >> 16]; }
+            if (value >= 0x100) { return 55 - Lookup[value >> 8]; }
+            return 63 - Lookup[value];
+        }
+    }
+}

--- a/HdrHistogram.Benchmarking/LeadingZeroCount/LeadingZeroCountBenchmarkBase.cs
+++ b/HdrHistogram.Benchmarking/LeadingZeroCount/LeadingZeroCountBenchmarkBase.cs
@@ -56,6 +56,7 @@ namespace HdrHistogram.Benchmarking.LeadingZeroCount
                 {"DeBruijn128Bits", LeadingZeroCount.DeBruijn128Bits.GetLeadingZeroCount},
                 {"BBarry32BitIfShiftLookupWith64BitShiftBranch", LeadingZeroCount.BBarry32BitIfShiftLookupWith64BitShiftBranch.GetLeadingZeroCount},
                 {"BBarry32BitIfShiftLookupWith64BitShiftBranch_2", LeadingZeroCount.BBarry32BitIfShiftLookupWith64BitShiftBranch_2.GetLeadingZeroCount},
+                {"BBarry32BitIfShiftLookupWith64BitShiftBranch_3", LeadingZeroCount.BBarry32BitIfShiftLookupWith64BitShiftBranch_3.GetLeadingZeroCount},
                 {"BBarryIfShiftLookup", LeadingZeroCount.BBarryIfShiftLookup.GetLeadingZeroCount},
             };
             ValidateImplementations(expectedData, functions);
@@ -190,6 +191,16 @@ namespace HdrHistogram.Benchmarking.LeadingZeroCount
             return sum;
         }
         [Benchmark]
+        public int BBarry_imp2()
+        {
+            var sum = 0;
+            for (int i = 0; i < _testValues.Length; i++)
+            {
+                sum += LeadingZeroCount.BBarryIfShiftLookup.GetLeadingZeroCount(_testValues[i]);
+            }
+            return sum;
+        }
+        [Benchmark]
         public int BBarry_imp3()
         {
             var sum = 0;
@@ -200,15 +211,16 @@ namespace HdrHistogram.Benchmarking.LeadingZeroCount
             return sum;
         }
         [Benchmark]
-        public int BBarry_imp2()
+        public int BBarry_imp4()
         {
             var sum = 0;
             for (int i = 0; i < _testValues.Length; i++)
             {
-                sum += LeadingZeroCount.BBarryIfShiftLookup.GetLeadingZeroCount(_testValues[i]);
+                sum += LeadingZeroCount.BBarry32BitIfShiftLookupWith64BitShiftBranch_3.GetLeadingZeroCount(_testValues[i]);
             }
             return sum;
         }
+
 
         private class CalculationExpectation
         {

--- a/build.cmd
+++ b/build.cmd
@@ -7,9 +7,15 @@ if [%1]==[] (
 )
 
 dotnet restore -v=q
+IF %ERRORLEVEL% NEQ 0 GOTO EOF
 
 dotnet build -v=q -c=Release /p:Version=%SemVer%
+IF %ERRORLEVEL% NEQ 0 GOTO EOF
 
 dotnet test .\HdrHistogram.UnitTests\HdrHistogram.UnitTests.csproj -v=q --no-build -c=Release
+IF %ERRORLEVEL% NEQ 0 GOTO EOF
 
 dotnet pack .\HdrHistogram\HdrHistogram.csproj --no-build --include-symbols -c=Release /p:Version=%SemVer%
+IF %ERRORLEVEL% NEQ 0 GOTO EOF
+
+.\HdrHistogram.Benchmarking\bin\Release\net47\HdrHistogram.Benchmarking.exe *


### PR DESCRIPTION
Adds benchmarks for proposed LZC implementations from @bbarry in #42.
The proposed style can be made to outperform the current implementation for CLR using LegacyJit, however performs poorly on the RyuJit (which appears to be the faster of the Jitters in these benchmarks).

The concept proposed is solid, and in retrospect quite an obvious and elegant solution.
Basically this is a 32bit lzc implmentation, but for value greater than `uint.Max` we perform right shift of the higher bits, allowing us to reuse the 32 bit code.
I was actually surprised that it wasn't faster in the end especially the final revision below.
```
        private const long IntOverflow = int.MaxValue + 1L;
        public static int GetLeadingZeroCount(long value)
        {
            if (value < IntOverflow)
                return 63 - Log2((uint)value);
            return 32 - Log2((uint)(value >> 31));
        }

        private const int Bit24Range = 0x1000000 - 1;
        private const int Bit16Range = 0x10000 - 1;
        private const int Bit8Range = 0x100 - 1;
        private static int Log2(uint i)
        {
            if (i > Bit24Range) { return Lookup[i >> 24] + 24; }
            if (i > Bit16Range) { return Lookup[i >> 16] + 16; }
            if (i > Bit8Range) { return Lookup[i >> 8] + 8; }
            return Lookup[i];
        }
```
On the best case it has only (2 branches, 1 lookup, 3 math operations)
The worst case is either 4 branches, 1 lookup and 1 math operation, or, 3 branches 1 lookup and 3 math operations).
I am not sure of the cost of the cast long-> uint.
