### PR TITLE
A fix for HistogramBase.AllValues() returning a repeat of the last HistogramIterationValue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,7 @@ Backup*/
 UpgradeLog*.XML
 
 Thumbs.db
+.vs/HdrHistogram/v15/Server/sqlite3/storage.ide-wal
+.vs/HdrHistogram/v15/Server/sqlite3/storage.ide-shm
+.vs/HdrHistogram/v15/Server/sqlite3/storage.ide
+.vs/HdrHistogram/v15/Server/sqlite3/db.lock

--- a/HdrHistogram.Benchmarking/HdrHistogram.Benchmarking.csproj
+++ b/HdrHistogram.Benchmarking/HdrHistogram.Benchmarking.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net47;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net471;netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.10.8" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net471'">
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows">
       <Version>0.10.8</Version>
     </PackageReference>

--- a/HdrHistogram.Examples/HdrHistogram.Examples.csproj
+++ b/HdrHistogram.Examples/HdrHistogram.Examples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HdrHistogram.UnitTests/HdrHistogram.UnitTests.csproj
+++ b/HdrHistogram.UnitTests/HdrHistogram.UnitTests.csproj
@@ -84,9 +84,10 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.2.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
 

--- a/HdrHistogram.UnitTests/HistogramEncodingTestBase.cs
+++ b/HdrHistogram.UnitTests/HistogramEncodingTestBase.cs
@@ -1,6 +1,8 @@
 ﻿using HdrHistogram.Encoding;
 using HdrHistogram.Utilities;
 using Xunit;
+using FluentAssertions;
+using System.Linq;
 
 namespace HdrHistogram.UnitTests
 {
@@ -19,6 +21,22 @@ namespace HdrHistogram.UnitTests
             Load(source);
             var result = EncodeDecode(source);
             HistogramAssert.AreValueEqual(source, result);
+        }
+
+        [Fact]
+        public void Given_a_populated_Histogram_iterating_over_buckets_gives_all_buckets()
+        {
+            var source = Create(DefaultHighestTrackableValue, DefaultSignificantFigures);
+            Load(source);
+            Iteration.HistogramIterationValue lastSeen = null;
+            foreach ( var v in source.AllValues().ToList() )
+            {
+                if ( lastSeen != null )
+                {
+                    v.Should().NotBe( lastSeen );
+                }
+                lastSeen = v;
+            }
         }
 
         [Fact]

--- a/HdrHistogram/Iteration/AbstractHistogramEnumerator.cs
+++ b/HdrHistogram/Iteration/AbstractHistogramEnumerator.cs
@@ -34,8 +34,13 @@ namespace HdrHistogram.Iteration
         protected int CurrentSubBucketIndex { get; private set; }
         protected long TotalCountToCurrentIndex { get; private set; }
         protected long CountAtThisValue { get; private set; }
-
-        public HistogramIterationValue Current { get; private set; }
+        
+        private HistogramIterationValue _current;
+        public HistogramIterationValue Current 
+        { 
+            get         => _current.Clone(); 
+            private set => _current = value; 
+        }
 
         protected AbstractHistogramEnumerator(HistogramBase histogram)
         {

--- a/HdrHistogram/Iteration/HistogramIterationValue.cs
+++ b/HdrHistogram/Iteration/HistogramIterationValue.cs
@@ -103,5 +103,7 @@ namespace HdrHistogram.Iteration
                     ", Percentile:" + Percentile +
                     ", PercentileLevelIteratedTo:" + PercentileLevelIteratedTo;
         }
+
+        public HistogramIterationValue Clone() => (HistogramIterationValue) this.MemberwiseClone();
     }
 }

--- a/README.md
+++ b/README.md
@@ -255,6 +255,12 @@ Next can you please ensure that your PR (Pull Request) has a comment in it descr
 Ideally if it is fixing an issue or a bug, there would be a Unit Test proving the fix and a reference to the Issues in the PR comments.
 
 
+### How to run tests?
+If you are having trouble running xunit tests out of the box, it is possible to run them using a version of the command line below. 
+You'll just need to fill in the correct value of $(SolutionDir), which should be as defined in Visual Studio.
+PS> dotnet C:\Users\%USERNAME%\.nuget\packages\xunit.runner.console\2.3.1\tools\netcoreapp2.0\xunit.console.dll $(SolutionDir)\HdrHistogram.UnitTests\bin\Debug\netcoreapp1.1\HdrHistogram.UnitTests.dll
+
+
 HdrHistogram Details
 ----------------------------------------------
 


### PR DESCRIPTION
I found that HistogramBase.AllValues() was returning an IEnumerable that contained the same HistogramIterationValue, which was the value of the last bucket in the histogram. This PR contains a test and a fix for this problem. 

Additionally, I also had some trouble building the project and running the tests on an out-of-the-box VS2017, so did some work to make that happen.