### PR TITLE
Deprecate dotnetcore1

### DIFF
--- a/HdrHistogram.Benchmarking/HdrHistogram.Benchmarking.csproj
+++ b/HdrHistogram.Benchmarking/HdrHistogram.Benchmarking.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net47;netcoreapp1.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net47;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HdrHistogram.Examples/HdrHistogram.Examples.csproj
+++ b/HdrHistogram.Examples/HdrHistogram.Examples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp1.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HdrHistogram.UnitTests/HdrHistogram.UnitTests.csproj
+++ b/HdrHistogram.UnitTests/HdrHistogram.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFrameworks>netcoreapp1.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: 2.{build}.0
 pull_requests:
   do_not_increment_build_number: true
-image: Visual Studio 2019
+image: Visual Studio 2022
 build_script:
 - ps: >-
     Write-Host $env:APPVEYOR_BUILD_VERSION


### PR DESCRIPTION

 - Removing references to `dotnetcoreapp1.1` target frameworks.
 - Updating to VS2022 on AppVeyor build server config