### PR TITLE
Net5.0

### DIFF
--- a/HdrHistogram.Benchmarking/HdrHistogram.Benchmarking.csproj
+++ b/HdrHistogram.Benchmarking/HdrHistogram.Benchmarking.csproj
@@ -2,11 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;net47;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.8" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows">
+      <Version>0.13.12</Version>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/HdrHistogram.Benchmarking/HdrHistogram.Benchmarking.csproj
+++ b/HdrHistogram.Benchmarking/HdrHistogram.Benchmarking.csproj
@@ -2,17 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net47;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.10.8" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows">
-      <Version>0.10.8</Version>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/HdrHistogram.Benchmarking/Program.cs
+++ b/HdrHistogram.Benchmarking/Program.cs
@@ -1,6 +1,6 @@
 ﻿using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Jobs;
-using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Environments;
 
@@ -10,14 +10,18 @@ namespace HdrHistogram.Benchmarking
     {
         static void Main(string[] args)
         {
-            var manualConfig = ManualConfig.Create(DefaultConfig.Instance);
-            manualConfig.Add(new MemoryDiagnoser());
-            //manualConfig.Add(new BenchmarkDotNet.Diagnostics.Windows.InliningDiagnoser());
-            //manualConfig.Add(HardwareCounter.BranchMispredictions, HardwareCounter.BranchInstructions);
-            var config = manualConfig
-                .With(Job.Clr.With(Jit.LegacyJit))
-                .With(Job.Clr.With(Jit.RyuJit))
-                .With(Job.Core.With(Jit.RyuJit));
+            var config = ManualConfig.Create(DefaultConfig.Instance)
+                //.AddDiagnoser(MemoryDiagnoser.Default)
+                .AddColumn(
+                    StatisticColumn.OperationsPerSecond,
+                    StatisticColumn.Mean, StatisticColumn.StdErr, StatisticColumn.StdDev,
+                    StatisticColumn.P0, StatisticColumn.Q1, StatisticColumn.P50, StatisticColumn.P67, StatisticColumn.Q3, StatisticColumn.P80, StatisticColumn.P90, StatisticColumn.P95, StatisticColumn.P100)
+                .AddJob(Job.Default.WithRuntime(ClrRuntime.Net481).WithJit(Jit.LegacyJit))
+                .AddJob(Job.Default.WithRuntime(ClrRuntime.Net481).WithJit(Jit.RyuJit))
+                .AddJob(Job.Default.WithRuntime(CoreRuntime.Core21))
+                .AddJob(Job.Default.WithRuntime(CoreRuntime.Core31))
+                .AddJob(Job.Default.WithRuntime(CoreRuntime.Core50))
+                ;
 
             var switcher = new BenchmarkSwitcher(new[] {
                 typeof(LeadingZeroCount.LeadingZeroCount64BitBenchmark),

--- a/HdrHistogram.Examples/HdrHistogram.Examples.csproj
+++ b/HdrHistogram.Examples/HdrHistogram.Examples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HdrHistogram/HdrHistogram.csproj
+++ b/HdrHistogram/HdrHistogram.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
     <Description>HdrHistogram supports low latency recording and analyzing of sampled data value counts across a configurable integer value range with configurable value precision within the range.</Description>
     <Authors>Gil Tene, Lee Campbell</Authors>
-    <PackageReleaseNotes>NetStandard 2.0 release</PackageReleaseNotes>
+    <PackageReleaseNotes>Net 5.0 release</PackageReleaseNotes>
     <Copyright>Copyright 2020</Copyright>
     <PackageTags>HdrHistogram HdrHistogram.NET Histogram Instrumentation</PackageTags>
     <PackageProjectUrl>https://github.com/HdrHistogram/HdrHistogram.NET</PackageProjectUrl>
@@ -14,14 +14,10 @@
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net45|AnyCPU'">
-    <DocumentationFile>bin\Release\net45\HdrHistogram.xml</DocumentationFile>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net.50|AnyCPU'">
+    <DocumentationFile>bin\Release\net50\HdrHistogram.xml</DocumentationFile>
   </PropertyGroup>
   
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard1.3|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard1.3\HdrHistogram.xml</DocumentationFile>
-    <DefineConstants>RELEASE;NETSTANDARD1_3</DefineConstants>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
     <DocumentationFile>bin\Release\netstandard2.0\HdrHistogram.xml</DocumentationFile>
     <DefineConstants>RELEASE;NETSTANDARD2_0</DefineConstants>

--- a/HdrHistogram/HdrHistogram.csproj
+++ b/HdrHistogram/HdrHistogram.csproj
@@ -14,8 +14,8 @@
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net.50|AnyCPU'">
-    <DocumentationFile>bin\Release\net50\HdrHistogram.xml</DocumentationFile>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net5.0|AnyCPU'">
+    <DocumentationFile>bin\Release\net5.0\HdrHistogram.xml</DocumentationFile>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">

--- a/build.cmd
+++ b/build.cmd
@@ -18,4 +18,4 @@ IF %ERRORLEVEL% NEQ 0 GOTO EOF
 dotnet pack .\HdrHistogram\HdrHistogram.csproj --no-build --include-symbols -c=Release /p:Version=%SemVer%
 IF %ERRORLEVEL% NEQ 0 GOTO EOF
 
-.\HdrHistogram.Benchmarking\bin\Release\net47\HdrHistogram.Benchmarking.exe *
+.\HdrHistogram.Benchmarking\bin\Release\net5.0\HdrHistogram.Benchmarking.exe *


### PR DESCRIPTION
Migrates up to .NET 5.0 with supporting updates.

- Remove net standard 1.3 from HDRHistogram
- Updates Benchmark dotnet (BDN) 0.13.12
- Add BDN target for coreapp3.1 and NET5.0
