### PR TITLE
Add net6.0 support

### DIFF
--- a/HdrHistogram.Benchmarking/HdrHistogram.Benchmarking.csproj
+++ b/HdrHistogram.Benchmarking/HdrHistogram.Benchmarking.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;net47;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;net47;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HdrHistogram.Benchmarking/Program.cs
+++ b/HdrHistogram.Benchmarking/Program.cs
@@ -21,6 +21,7 @@ namespace HdrHistogram.Benchmarking
                 .AddJob(Job.Default.WithRuntime(CoreRuntime.Core21))
                 .AddJob(Job.Default.WithRuntime(CoreRuntime.Core31))
                 .AddJob(Job.Default.WithRuntime(CoreRuntime.Core50))
+                .AddJob(Job.Default.WithRuntime(CoreRuntime.Core60))
                 ;
 
             var switcher = new BenchmarkSwitcher(new[] {

--- a/HdrHistogram/HdrHistogram.csproj
+++ b/HdrHistogram/HdrHistogram.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <Description>HdrHistogram supports low latency recording and analyzing of sampled data value counts across a configurable integer value range with configurable value precision within the range.</Description>
     <Authors>Gil Tene, Lee Campbell</Authors>
-    <PackageReleaseNotes>Net 5.0 release</PackageReleaseNotes>
-    <Copyright>Copyright 2020</Copyright>
+    <PackageReleaseNotes>Net 6.0 release</PackageReleaseNotes>
+    <Copyright>Copyright 2024</Copyright>
     <PackageTags>HdrHistogram HdrHistogram.NET Histogram Instrumentation</PackageTags>
     <PackageProjectUrl>https://github.com/HdrHistogram/HdrHistogram.NET</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/HdrHistogram/HdrHistogram.NET/master/LICENSE.txt</PackageLicenseUrl>
@@ -14,8 +14,8 @@
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net5.0|AnyCPU'">
-    <DocumentationFile>bin\Release\net5.0\HdrHistogram.xml</DocumentationFile>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net6.0|AnyCPU'">
+    <DocumentationFile>bin\Release\net6.0\HdrHistogram.xml</DocumentationFile>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">

--- a/build.cmd
+++ b/build.cmd
@@ -18,4 +18,4 @@ IF %ERRORLEVEL% NEQ 0 GOTO EOF
 dotnet pack .\HdrHistogram\HdrHistogram.csproj --no-build --include-symbols -c=Release /p:Version=%SemVer%
 IF %ERRORLEVEL% NEQ 0 GOTO EOF
 
-.\HdrHistogram.Benchmarking\bin\Release\net5.0\HdrHistogram.Benchmarking.exe *
+.\HdrHistogram.Benchmarking\bin\Release\net6.0\HdrHistogram.Benchmarking.exe *


### PR DESCRIPTION
Adding .NET 6.0 Support.
Seeing ~20% improvements in `IntHistogramRecording` and `ShortHistogramRecording` benchmarks.