### PR TITLE
Add net7.0 support

### DIFF
--- a/HdrHistogram.Benchmarking/HdrHistogram.Benchmarking.csproj
+++ b/HdrHistogram.Benchmarking/HdrHistogram.Benchmarking.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net5.0;net47;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;net5.0;net47;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HdrHistogram.Benchmarking/Program.cs
+++ b/HdrHistogram.Benchmarking/Program.cs
@@ -22,6 +22,7 @@ namespace HdrHistogram.Benchmarking
                 .AddJob(Job.Default.WithRuntime(CoreRuntime.Core31))
                 .AddJob(Job.Default.WithRuntime(CoreRuntime.Core50))
                 .AddJob(Job.Default.WithRuntime(CoreRuntime.Core60))
+                .AddJob(Job.Default.WithRuntime(CoreRuntime.Core70))
                 ;
 
             var switcher = new BenchmarkSwitcher(new[] {

--- a/build.cmd
+++ b/build.cmd
@@ -18,4 +18,4 @@ IF %ERRORLEVEL% NEQ 0 GOTO EOF
 dotnet pack .\HdrHistogram\HdrHistogram.csproj --no-build --include-symbols -c=Release /p:Version=%SemVer%
 IF %ERRORLEVEL% NEQ 0 GOTO EOF
 
-.\HdrHistogram.Benchmarking\bin\Release\net6.0\HdrHistogram.Benchmarking.exe *
+.\HdrHistogram.Benchmarking\bin\Release\net7.0\HdrHistogram.Benchmarking.exe *


### PR DESCRIPTION
Adding .NET 7.0 Support.
Seeing small (1-9%) improvements in `LongHistogramRecording`, `IntHistogramRecording` and `ShortHistogramRecording` benchmarks.