### PR TITLE
Add net8.0 support

### DIFF
--- a/HdrHistogram.Benchmarking/HdrHistogram.Benchmarking.csproj
+++ b/HdrHistogram.Benchmarking/HdrHistogram.Benchmarking.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0;net6.0;net5.0;net47;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;net47;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HdrHistogram.Benchmarking/Program.cs
+++ b/HdrHistogram.Benchmarking/Program.cs
@@ -23,6 +23,7 @@ namespace HdrHistogram.Benchmarking
                 .AddJob(Job.Default.WithRuntime(CoreRuntime.Core50))
                 .AddJob(Job.Default.WithRuntime(CoreRuntime.Core60))
                 .AddJob(Job.Default.WithRuntime(CoreRuntime.Core70))
+                .AddJob(Job.Default.WithRuntime(CoreRuntime.Core80))
                 ;
 
             var switcher = new BenchmarkSwitcher(new[] {

--- a/HdrHistogram/HdrHistogram.csproj
+++ b/HdrHistogram/HdrHistogram.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <Description>HdrHistogram supports low latency recording and analyzing of sampled data value counts across a configurable integer value range with configurable value precision within the range.</Description>
     <Authors>Gil Tene, Lee Campbell</Authors>
-    <PackageReleaseNotes>Net 6.0 release</PackageReleaseNotes>
+    <PackageReleaseNotes>Net 8.0 release</PackageReleaseNotes>
     <Copyright>Copyright 2024</Copyright>
     <PackageTags>HdrHistogram HdrHistogram.NET Histogram Instrumentation</PackageTags>
     <PackageProjectUrl>https://github.com/HdrHistogram/HdrHistogram.NET</PackageProjectUrl>
@@ -14,8 +14,8 @@
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net6.0|AnyCPU'">
-    <DocumentationFile>bin\Release\net6.0\HdrHistogram.xml</DocumentationFile>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0|AnyCPU'">
+    <DocumentationFile>bin\Release\net8.0\HdrHistogram.xml</DocumentationFile>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">

--- a/build.cmd
+++ b/build.cmd
@@ -18,4 +18,4 @@ IF %ERRORLEVEL% NEQ 0 GOTO EOF
 dotnet pack .\HdrHistogram\HdrHistogram.csproj --no-build --include-symbols -c=Release /p:Version=%SemVer%
 IF %ERRORLEVEL% NEQ 0 GOTO EOF
 
-.\HdrHistogram.Benchmarking\bin\Release\net7.0\HdrHistogram.Benchmarking.exe *
+.\HdrHistogram.Benchmarking\bin\Release\net8.0\HdrHistogram.Benchmarking.exe *


### PR DESCRIPTION
 - Update to support net8.0. ~40% perf improvement `LongHistogramRecording` from NET7 to NET8. 👏 


Benchmark summary output:


```shell
// * Summary *

BenchmarkDotNet v0.13.12, Windows 10 (10.0.19045.4717/22H2/2022Update)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET SDK 8.0.303
  [Host]     : .NET 8.0.7 (8.0.724.31311), X64 RyuJIT AVX2
  Job-DBDESG : .NET Framework 4.8.1 (4.8.9261.0), X64 RyuJIT VectorSize=256
  Job-KTPTYZ : .NET Framework 4.8.1 (4.8.9261.0), X64 RyuJIT VectorSize=256
  Job-PAKZMW : .NET 5.0.17 (5.0.1722.21314), X64 RyuJIT AVX2
  Job-FIWRZU : .NET 6.0.32 (6.0.3224.31407), X64 RyuJIT AVX2
  Job-OBEPJZ : .NET 7.0.20 (7.0.2024.26716), X64 RyuJIT AVX2
  Job-KXYDVB : .NET 8.0.7 (8.0.724.31311), X64 RyuJIT AVX2
  Job-HUAVPF : .NET Core 2.1.30 (CoreCLR 4.6.30411.01, CoreFX 4.6.30411.02), X64 RyuJIT AVX2
  Job-VWKWSZ : .NET Core 3.1.32 (CoreCLR 4.700.22.55902, CoreFX 4.700.22.56512), X64 RyuJIT AVX2


| Method                           | Jit       | Runtime              | Mean       | Error    | StdDev    | StdErr   | Median     | Q1         | Q3         | P0         | P50        | P67        | P80        | P90        | P95        | P100       | Op/s        | Ratio | RatioSD |
|--------------------------------- |---------- |--------------------- |-----------:|---------:|----------:|---------:|-----------:|-----------:|-----------:|-----------:|-----------:|-----------:|-----------:|-----------:|-----------:|-----------:|------------:|------:|--------:|
| LongHistogramRecording           | LegacyJit | .NET Framework 4.8.1 |   882.9 ns | 17.02 ns |  20.90 ns |  4.46 ns |   883.4 ns |   866.7 ns |   897.4 ns |   854.0 ns |   883.4 ns |   892.9 ns |   900.5 ns |   905.9 ns |   906.8 ns |   936.7 ns | 1,132,574.3 |  1.00 |    0.00 |
| LongConcurrentHistogramRecording | LegacyJit | .NET Framework 4.8.1 | 3,031.4 ns | 48.45 ns |  49.76 ns | 12.07 ns | 3,029.9 ns | 3,003.3 ns | 3,075.4 ns | 2,946.7 ns | 3,029.9 ns | 3,069.2 ns | 3,078.4 ns | 3,084.6 ns | 3,088.5 ns | 3,103.6 ns |   329,877.9 |  3.43 |    0.11 |
| IntHistogramRecording            | LegacyJit | .NET Framework 4.8.1 | 1,034.9 ns | 45.11 ns | 130.88 ns | 13.29 ns |   999.1 ns |   938.8 ns | 1,115.6 ns |   887.7 ns |   999.1 ns | 1,054.0 ns | 1,136.2 ns | 1,226.7 ns | 1,308.3 ns | 1,396.8 ns |   966,311.8 |  1.22 |    0.16 |
| IntConcurrentHistogramRecording  | LegacyJit | .NET Framework 4.8.1 | 3,019.3 ns | 53.50 ns |  50.04 ns | 12.92 ns | 3,010.2 ns | 2,988.8 ns | 3,045.0 ns | 2,954.8 ns | 3,010.2 ns | 3,015.7 ns | 3,074.8 ns | 3,091.2 ns | 3,103.7 ns | 3,113.6 ns |   331,202.9 |  3.42 |    0.11 |
| ShortHistogramRecording          | LegacyJit | .NET Framework 4.8.1 |   860.8 ns | 36.83 ns | 104.48 ns | 10.83 ns |   821.5 ns |   785.8 ns |   919.1 ns |   758.8 ns |   821.5 ns |   866.5 ns |   924.5 ns | 1,026.5 ns | 1,086.8 ns | 1,155.4 ns | 1,161,678.5 |  1.02 |    0.14 |
| LongRecorderRecording            | LegacyJit | .NET Framework 4.8.1 | 1,984.4 ns | 39.44 ns |  59.03 ns | 10.78 ns | 1,960.9 ns | 1,930.3 ns | 2,053.4 ns | 1,919.9 ns | 1,960.9 ns | 2,033.8 ns | 2,055.3 ns | 2,060.1 ns | 2,068.6 ns | 2,080.2 ns |   503,936.3 |  2.25 |    0.08 |
| LongConcurrentRecorderRecording  | LegacyJit | .NET Framework 4.8.1 | 4,158.1 ns | 77.60 ns |  72.58 ns | 18.74 ns | 4,168.4 ns | 4,097.0 ns | 4,208.9 ns | 4,030.7 ns | 4,168.4 ns | 4,193.5 ns | 4,223.5 ns | 4,227.0 ns | 4,241.3 ns | 4,273.4 ns |   240,496.2 |  4.71 |    0.14 |
| IntRecorderRecording             | LegacyJit | .NET Framework 4.8.1 | 1,978.8 ns | 39.02 ns |  68.34 ns | 10.94 ns | 1,954.5 ns | 1,922.1 ns | 2,040.9 ns | 1,910.5 ns | 1,954.5 ns | 1,985.8 ns | 2,047.7 ns | 2,080.4 ns | 2,100.6 ns | 2,144.1 ns |   505,356.4 |  2.24 |    0.08 |
| IntConcurrentRecorderRecording   | LegacyJit | .NET Framework 4.8.1 | 4,923.1 ns | 96.59 ns | 147.50 ns | 26.49 ns | 4,875.5 ns | 4,810.5 ns | 5,026.4 ns | 4,743.3 ns | 4,875.5 ns | 4,997.6 ns | 5,038.9 ns | 5,099.4 ns | 5,175.5 ns | 5,322.2 ns |   203,122.2 |  5.60 |    0.17 |
| ShortRecorderRecording           | LegacyJit | .NET Framework 4.8.1 | 1,989.8 ns | 39.68 ns |  66.30 ns | 11.05 ns | 1,965.6 ns | 1,938.3 ns | 2,051.2 ns | 1,919.8 ns | 1,965.6 ns | 1,997.3 ns | 2,059.2 ns | 2,077.7 ns | 2,118.3 ns | 2,148.1 ns |   502,557.8 |  2.27 |    0.11 |
|                                  |           |                      |            |          |           |          |            |            |            |            |            |            |            |            |            |            |             |       |         |
| LongHistogramRecording           | RyuJit    | .NET Framework 4.8.1 |   878.0 ns | 16.56 ns |  16.26 ns |  4.07 ns |   876.7 ns |   862.7 ns |   891.8 ns |   856.1 ns |   876.7 ns |   890.4 ns |   895.6 ns |   897.3 ns |   898.9 ns |   903.6 ns | 1,138,975.4 |  1.00 |    0.00 |
| LongConcurrentHistogramRecording | RyuJit    | .NET Framework 4.8.1 | 3,029.6 ns | 59.14 ns |  72.63 ns | 15.48 ns | 2,997.1 ns | 2,971.4 ns | 3,078.5 ns | 2,945.0 ns | 2,997.1 ns | 3,070.4 ns | 3,082.5 ns | 3,093.0 ns | 3,167.9 ns | 3,210.7 ns |   330,074.9 |  3.45 |    0.12 |
| IntHistogramRecording            | RyuJit    | .NET Framework 4.8.1 |   933.4 ns | 18.26 ns |  25.60 ns |  4.93 ns |   931.3 ns |   918.4 ns |   948.1 ns |   893.0 ns |   931.3 ns |   942.1 ns |   952.2 ns |   967.3 ns |   969.6 ns |   994.4 ns | 1,071,340.1 |  1.06 |    0.04 |
| IntConcurrentHistogramRecording  | RyuJit    | .NET Framework 4.8.1 | 3,029.7 ns | 59.57 ns |  58.50 ns | 14.63 ns | 3,018.4 ns | 2,980.0 ns | 3,079.4 ns | 2,946.6 ns | 3,018.4 ns | 3,071.2 ns | 3,097.6 ns | 3,102.5 ns | 3,105.3 ns | 3,107.2 ns |   330,060.5 |  3.45 |    0.05 |
| ShortHistogramRecording          | RyuJit    | .NET Framework 4.8.1 |   774.4 ns | 15.33 ns |  17.04 ns |  3.91 ns |   769.7 ns |   761.7 ns |   789.1 ns |   752.6 ns |   769.7 ns |   782.1 ns |   792.2 ns |   794.8 ns |   799.2 ns |   811.4 ns | 1,291,343.4 |  0.88 |    0.03 |
| LongRecorderRecording            | RyuJit    | .NET Framework 4.8.1 | 2,012.1 ns | 39.53 ns |  69.23 ns | 11.09 ns | 2,009.2 ns | 1,949.8 ns | 2,061.6 ns | 1,919.8 ns | 2,009.2 ns | 2,038.3 ns | 2,072.1 ns | 2,095.6 ns | 2,119.5 ns | 2,179.3 ns |   497,003.7 |  2.33 |    0.10 |
| LongConcurrentRecorderRecording  | RyuJit    | .NET Framework 4.8.1 | 4,126.9 ns | 81.69 ns | 117.16 ns | 22.14 ns | 4,090.5 ns | 4,024.4 ns | 4,205.5 ns | 4,000.9 ns | 4,090.5 ns | 4,152.4 ns | 4,263.8 ns | 4,312.8 ns | 4,326.5 ns | 4,342.8 ns |   242,312.8 |  4.70 |    0.19 |
| IntRecorderRecording             | RyuJit    | .NET Framework 4.8.1 | 1,973.4 ns | 39.17 ns |  57.42 ns | 10.66 ns | 1,967.1 ns | 1,924.6 ns | 2,003.9 ns | 1,908.9 ns | 1,967.1 ns | 1,993.4 ns | 2,040.1 ns | 2,062.8 ns | 2,065.1 ns | 2,085.3 ns |   506,745.7 |  2.25 |    0.08 |
| IntConcurrentRecorderRecording   | RyuJit    | .NET Framework 4.8.1 | 4,098.5 ns | 80.11 ns |  78.68 ns | 19.67 ns | 4,081.5 ns | 4,042.7 ns | 4,137.5 ns | 3,991.9 ns | 4,081.5 ns | 4,120.0 ns | 4,140.4 ns | 4,202.6 ns | 4,235.8 ns | 4,272.9 ns |   243,991.6 |  4.67 |    0.13 |
| ShortRecorderRecording           | RyuJit    | .NET Framework 4.8.1 | 1,992.3 ns | 38.56 ns |  52.79 ns | 10.35 ns | 1,991.8 ns | 1,934.7 ns | 2,035.2 ns | 1,925.7 ns | 1,991.8 ns | 2,024.8 ns | 2,044.1 ns | 2,060.0 ns | 2,068.6 ns | 2,082.9 ns |   501,938.1 |  2.26 |    0.08 |
|                                  |           |                      |            |          |           |          |            |            |            |            |            |            |            |            |            |            |             |       |         |
| LongHistogramRecording           | RyuJit    | .NET 5.0             |   805.6 ns | 15.99 ns |  14.96 ns |  3.86 ns |   806.3 ns |   795.7 ns |   814.1 ns |   778.9 ns |   806.3 ns |   811.9 ns |   814.4 ns |   816.5 ns |   824.8 ns |   842.2 ns | 1,241,369.5 |  1.00 |    0.00 |
| LongConcurrentHistogramRecording | RyuJit    | .NET 5.0             | 2,735.7 ns | 51.17 ns |  47.87 ns | 12.36 ns | 2,727.3 ns | 2,702.3 ns | 2,760.9 ns | 2,669.8 ns | 2,727.3 ns | 2,731.5 ns | 2,790.8 ns | 2,805.4 ns | 2,814.6 ns | 2,824.4 ns |   365,538.4 |  3.40 |    0.09 |
| IntHistogramRecording            | RyuJit    | .NET 5.0             |   850.3 ns | 32.94 ns |  91.29 ns |  9.68 ns |   809.8 ns |   790.6 ns |   881.7 ns |   762.1 ns |   809.8 ns |   850.9 ns |   907.5 ns | 1,015.2 ns | 1,062.5 ns | 1,108.3 ns | 1,176,085.0 |  1.11 |    0.12 |
| IntConcurrentHistogramRecording  | RyuJit    | .NET 5.0             | 2,783.9 ns | 51.88 ns |  50.96 ns | 12.74 ns | 2,773.2 ns | 2,752.8 ns | 2,837.8 ns | 2,714.9 ns | 2,773.2 ns | 2,782.1 ns | 2,840.4 ns | 2,852.8 ns | 2,865.1 ns | 2,867.6 ns |   359,212.5 |  3.46 |    0.11 |
| ShortHistogramRecording          | RyuJit    | .NET 5.0             |   916.5 ns | 37.97 ns | 107.72 ns | 11.17 ns |   864.7 ns |   836.4 ns |   967.5 ns |   811.4 ns |   864.7 ns |   923.1 ns |   999.2 ns | 1,087.9 ns | 1,160.2 ns | 1,219.9 ns | 1,091,163.3 |  1.22 |    0.13 |
| LongRecorderRecording            | RyuJit    | .NET 5.0             | 1,996.1 ns | 39.81 ns |  61.99 ns | 10.96 ns | 1,976.2 ns | 1,949.3 ns | 2,041.9 ns | 1,917.2 ns | 1,976.2 ns | 2,003.5 ns | 2,063.2 ns | 2,089.2 ns | 2,103.9 ns | 2,145.0 ns |   500,986.7 |  2.49 |    0.09 |
| LongConcurrentRecorderRecording  | RyuJit    | .NET 5.0             | 4,025.2 ns | 77.86 ns | 114.12 ns | 21.19 ns | 3,974.0 ns | 3,924.9 ns | 4,131.9 ns | 3,901.6 ns | 3,974.0 ns | 4,073.8 ns | 4,163.7 ns | 4,193.8 ns | 4,221.9 ns | 4,234.0 ns |   248,436.3 |  4.96 |    0.16 |
| IntRecorderRecording             | RyuJit    | .NET 5.0             | 1,986.3 ns | 39.22 ns |  51.00 ns | 10.41 ns | 1,979.2 ns | 1,941.1 ns | 2,026.9 ns | 1,917.8 ns | 1,979.2 ns | 2,006.9 ns | 2,037.2 ns | 2,063.0 ns | 2,067.1 ns | 2,070.7 ns |   503,448.6 |  2.46 |    0.08 |
| IntConcurrentRecorderRecording   | RyuJit    | .NET 5.0             | 3,978.1 ns | 77.38 ns | 103.30 ns | 20.66 ns | 3,972.2 ns | 3,881.2 ns | 4,036.6 ns | 3,850.8 ns | 3,972.2 ns | 4,006.6 ns | 4,041.7 ns | 4,130.4 ns | 4,154.8 ns | 4,220.7 ns |   251,378.5 |  4.96 |    0.17 |
| ShortRecorderRecording           | RyuJit    | .NET 5.0             | 1,969.3 ns | 36.24 ns |  43.14 ns |  9.41 ns | 1,958.2 ns | 1,932.0 ns | 1,986.7 ns | 1,916.9 ns | 1,958.2 ns | 1,982.2 ns | 1,996.6 ns | 2,031.3 ns | 2,057.1 ns | 2,065.7 ns |   507,790.0 |  2.45 |    0.08 |
|                                  |           |                      |            |          |           |          |            |            |            |            |            |            |            |            |            |            |             |       |         |
| LongHistogramRecording           | RyuJit    | .NET 6.0             |   702.4 ns | 13.78 ns |  19.31 ns |  3.72 ns |   699.8 ns |   684.4 ns |   716.4 ns |   677.2 ns |   699.8 ns |   713.8 ns |   719.0 ns |   726.0 ns |   730.6 ns |   748.1 ns | 1,423,608.1 |  1.00 |    0.00 |
| LongConcurrentHistogramRecording | RyuJit    | .NET 6.0             | 2,665.6 ns | 52.27 ns |  60.19 ns | 13.46 ns | 2,643.5 ns | 2,623.3 ns | 2,716.5 ns | 2,593.1 ns | 2,643.5 ns | 2,692.5 ns | 2,730.9 ns | 2,736.0 ns | 2,743.6 ns | 2,813.3 ns |   375,153.5 |  3.79 |    0.13 |
| IntHistogramRecording            | RyuJit    | .NET 6.0             |   771.1 ns | 29.65 ns |  85.07 ns |  8.73 ns |   741.1 ns |   706.2 ns |   824.8 ns |   675.5 ns |   741.1 ns |   782.3 ns |   840.1 ns |   907.0 ns |   953.5 ns | 1,004.3 ns | 1,296,864.5 |  1.09 |    0.11 |
| IntConcurrentHistogramRecording  | RyuJit    | .NET 6.0             | 2,765.9 ns | 43.75 ns |  40.92 ns | 10.57 ns | 2,752.0 ns | 2,741.3 ns | 2,796.6 ns | 2,703.3 ns | 2,752.0 ns | 2,773.1 ns | 2,807.0 ns | 2,819.2 ns | 2,827.7 ns | 2,844.2 ns |   361,547.0 |  3.93 |    0.16 |
| ShortHistogramRecording          | RyuJit    | .NET 6.0             |   761.1 ns | 33.89 ns |  95.60 ns |  9.97 ns |   724.3 ns |   685.9 ns |   818.2 ns |   656.4 ns |   724.3 ns |   782.9 ns |   836.2 ns |   901.1 ns |   952.4 ns | 1,031.9 ns | 1,313,834.8 |  1.07 |    0.15 |
| LongRecorderRecording            | RyuJit    | .NET 6.0             | 1,876.8 ns | 37.47 ns |  52.53 ns | 10.11 ns | 1,852.1 ns | 1,828.9 ns | 1,915.1 ns | 1,819.5 ns | 1,852.1 ns | 1,902.4 ns | 1,922.6 ns | 1,962.4 ns | 1,968.1 ns | 1,971.6 ns |   532,826.1 |  2.67 |    0.12 |
| LongConcurrentRecorderRecording  | RyuJit    | .NET 6.0             | 3,972.8 ns | 78.40 ns |  93.33 ns | 20.37 ns | 3,962.2 ns | 3,888.7 ns | 4,015.9 ns | 3,870.8 ns | 3,962.2 ns | 3,995.5 ns | 4,065.0 ns | 4,121.9 ns | 4,128.1 ns | 4,138.1 ns |   251,709.0 |  5.66 |    0.17 |
| IntRecorderRecording             | RyuJit    | .NET 6.0             | 1,855.6 ns | 21.51 ns |  20.12 ns |  5.19 ns | 1,857.9 ns | 1,836.7 ns | 1,873.1 ns | 1,827.3 ns | 1,857.9 ns | 1,871.4 ns | 1,875.5 ns | 1,880.6 ns | 1,882.4 ns | 1,882.8 ns |   538,907.6 |  2.63 |    0.09 |
| IntConcurrentRecorderRecording   | RyuJit    | .NET 6.0             | 3,966.4 ns | 79.16 ns | 102.93 ns | 21.01 ns | 3,955.7 ns | 3,883.7 ns | 4,012.1 ns | 3,850.7 ns | 3,955.7 ns | 3,978.9 ns | 4,047.7 ns | 4,136.6 ns | 4,155.4 ns | 4,170.3 ns |   252,119.8 |  5.65 |    0.24 |
| ShortRecorderRecording           | RyuJit    | .NET 6.0             | 1,865.1 ns | 24.30 ns |  22.73 ns |  5.87 ns | 1,856.5 ns | 1,850.3 ns | 1,887.4 ns | 1,829.8 ns | 1,856.5 ns | 1,882.6 ns | 1,889.5 ns | 1,891.6 ns | 1,892.3 ns | 1,892.3 ns |   536,161.9 |  2.65 |    0.08 |
|                                  |           |                      |            |          |           |          |            |            |            |            |            |            |            |            |            |            |             |       |         |
| LongHistogramRecording           | RyuJit    | .NET 7.0             |   645.4 ns | 12.48 ns |  16.66 ns |  3.33 ns |   641.2 ns |   631.1 ns |   656.9 ns |   623.6 ns |   641.2 ns |   648.9 ns |   660.4 ns |   672.2 ns |   676.6 ns |   677.8 ns | 1,549,420.0 |  1.00 |    0.00 |
| LongConcurrentHistogramRecording | RyuJit    | .NET 7.0             | 2,433.9 ns | 48.02 ns |  62.43 ns | 12.74 ns | 2,412.0 ns | 2,387.8 ns | 2,503.9 ns | 2,357.5 ns | 2,412.0 ns | 2,429.7 ns | 2,508.2 ns | 2,535.2 ns | 2,539.9 ns | 2,544.2 ns |   410,859.6 |  3.77 |    0.14 |
| IntHistogramRecording            | RyuJit    | .NET 7.0             |   708.8 ns | 34.07 ns |  96.65 ns | 10.02 ns |   688.9 ns |   629.4 ns |   754.8 ns |   590.3 ns |   688.9 ns |   730.1 ns |   772.5 ns |   848.2 ns |   910.1 ns |   989.9 ns | 1,410,888.0 |  1.06 |    0.11 |
| IntConcurrentHistogramRecording  | RyuJit    | .NET 7.0             | 2,598.9 ns | 49.91 ns |  49.02 ns | 12.25 ns | 2,578.1 ns | 2,561.2 ns | 2,641.4 ns | 2,537.4 ns | 2,578.1 ns | 2,622.1 ns | 2,649.8 ns | 2,668.9 ns | 2,679.0 ns | 2,684.7 ns |   384,781.1 |  4.03 |    0.11 |
| ShortHistogramRecording          | RyuJit    | .NET 7.0             |   740.8 ns | 42.18 ns | 122.38 ns | 12.43 ns |   704.3 ns |   635.2 ns |   812.0 ns |   584.7 ns |   704.3 ns |   792.5 ns |   845.5 ns |   931.6 ns |   994.1 ns | 1,041.8 ns | 1,349,953.9 |  1.12 |    0.19 |
| LongRecorderRecording            | RyuJit    | .NET 7.0             | 1,782.0 ns | 35.52 ns |  47.42 ns |  9.48 ns | 1,769.4 ns | 1,745.6 ns | 1,822.1 ns | 1,722.0 ns | 1,769.4 ns | 1,783.0 ns | 1,832.4 ns | 1,857.5 ns | 1,860.5 ns | 1,879.2 ns |   561,176.8 |  2.76 |    0.11 |
| LongConcurrentRecorderRecording  | RyuJit    | .NET 7.0             | 3,651.8 ns | 68.38 ns |  63.96 ns | 16.51 ns | 3,633.2 ns | 3,614.0 ns | 3,698.2 ns | 3,565.2 ns | 3,633.2 ns | 3,692.2 ns | 3,702.4 ns | 3,727.8 ns | 3,752.7 ns | 3,777.1 ns |   273,838.9 |  5.65 |    0.16 |
| IntRecorderRecording             | RyuJit    | .NET 7.0             | 1,773.9 ns | 25.06 ns |  23.45 ns |  6.05 ns | 1,767.9 ns | 1,760.7 ns | 1,794.9 ns | 1,734.6 ns | 1,767.9 ns | 1,789.9 ns | 1,796.1 ns | 1,801.5 ns | 1,805.5 ns | 1,808.4 ns |   563,740.9 |  2.74 |    0.08 |
| IntConcurrentRecorderRecording   | RyuJit    | .NET 7.0             | 3,819.7 ns | 67.62 ns | 120.19 ns | 19.00 ns | 3,771.0 ns | 3,715.6 ns | 3,921.6 ns | 3,693.7 ns | 3,771.0 ns | 3,844.1 ns | 3,954.8 ns | 3,982.0 ns | 4,040.7 ns | 4,109.9 ns |   261,803.1 |  5.91 |    0.22 |
| ShortRecorderRecording           | RyuJit    | .NET 7.0             | 1,769.7 ns | 25.14 ns |  23.51 ns |  6.07 ns | 1,763.2 ns | 1,750.5 ns | 1,792.5 ns | 1,738.7 ns | 1,763.2 ns | 1,786.8 ns | 1,794.0 ns | 1,796.4 ns | 1,799.5 ns | 1,805.5 ns |   565,056.1 |  2.74 |    0.06 |
|                                  |           |                      |            |          |           |          |            |            |            |            |            |            |            |            |            |            |             |       |         |
| LongHistogramRecording           | RyuJit    | .NET 8.0             |   448.2 ns |  8.95 ns |  16.59 ns |  2.53 ns |   437.4 ns |   434.2 ns |   461.5 ns |   430.6 ns |   437.4 ns |   459.0 ns |   464.0 ns |   470.5 ns |   473.4 ns |   494.6 ns | 2,231,174.1 |  1.00 |    0.00 |
| LongConcurrentHistogramRecording | RyuJit    | .NET 8.0             | 2,310.0 ns | 44.01 ns |  48.92 ns | 11.22 ns | 2,297.1 ns | 2,266.5 ns | 2,345.6 ns | 2,245.8 ns | 2,297.1 ns | 2,323.4 ns | 2,370.3 ns | 2,378.5 ns | 2,380.7 ns | 2,399.4 ns |   432,909.7 |  5.15 |    0.23 |
| IntHistogramRecording            | RyuJit    | .NET 8.0             |   515.2 ns | 26.97 ns |  78.25 ns |  7.95 ns |   479.1 ns |   454.6 ns |   556.8 ns |   438.0 ns |   479.1 ns |   527.2 ns |   581.4 ns |   644.8 ns |   684.9 ns |   743.8 ns | 1,941,043.4 |  1.17 |    0.19 |
| IntConcurrentHistogramRecording  | RyuJit    | .NET 8.0             | 2,592.4 ns | 51.69 ns |  53.09 ns | 12.88 ns | 2,579.1 ns | 2,553.1 ns | 2,647.5 ns | 2,523.5 ns | 2,579.1 ns | 2,596.4 ns | 2,650.0 ns | 2,669.3 ns | 2,677.0 ns | 2,686.4 ns |   385,738.7 |  5.80 |    0.25 |
| ShortHistogramRecording          | RyuJit    | .NET 8.0             |   392.7 ns | 18.01 ns |  51.68 ns |  5.30 ns |   374.1 ns |   354.3 ns |   420.1 ns |   335.9 ns |   374.1 ns |   398.2 ns |   429.0 ns |   476.8 ns |   503.0 ns |   526.3 ns | 2,546,601.2 |  0.84 |    0.11 |
| LongRecorderRecording            | RyuJit    | .NET 8.0             | 1,654.9 ns | 28.93 ns |  27.06 ns |  6.99 ns | 1,656.6 ns | 1,636.3 ns | 1,677.4 ns | 1,609.3 ns | 1,656.6 ns | 1,674.0 ns | 1,679.4 ns | 1,681.9 ns | 1,686.8 ns | 1,695.9 ns |   604,270.5 |  3.69 |    0.15 |
| LongConcurrentRecorderRecording  | RyuJit    | .NET 8.0             | 3,613.0 ns | 52.68 ns |  49.28 ns | 12.72 ns | 3,616.5 ns | 3,568.4 ns | 3,651.6 ns | 3,536.0 ns | 3,616.5 ns | 3,648.4 ns | 3,654.1 ns | 3,665.3 ns | 3,675.9 ns | 3,695.5 ns |   276,779.8 |  8.05 |    0.23 |
| IntRecorderRecording             | RyuJit    | .NET 8.0             | 1,706.8 ns | 33.74 ns |  58.21 ns |  9.44 ns | 1,692.1 ns | 1,661.2 ns | 1,741.2 ns | 1,631.4 ns | 1,692.1 ns | 1,728.5 ns | 1,755.2 ns | 1,775.5 ns | 1,839.7 ns | 1,844.8 ns |   585,904.3 |  3.82 |    0.18 |
| IntConcurrentRecorderRecording   | RyuJit    | .NET 8.0             | 3,570.1 ns | 50.69 ns |  47.41 ns | 12.24 ns | 3,575.3 ns | 3,537.7 ns | 3,609.9 ns | 3,485.1 ns | 3,575.3 ns | 3,605.4 ns | 3,612.4 ns | 3,623.1 ns | 3,631.9 ns | 3,642.8 ns |   280,101.7 |  7.96 |    0.21 |
| ShortRecorderRecording           | RyuJit    | .NET 8.0             | 1,645.8 ns | 29.39 ns |  24.54 ns |  6.81 ns | 1,632.9 ns | 1,631.3 ns | 1,670.8 ns | 1,612.6 ns | 1,632.9 ns | 1,670.2 ns | 1,673.4 ns | 1,675.6 ns | 1,677.1 ns | 1,679.2 ns |   607,593.4 |  3.67 |    0.15 |
|                                  |           |                      |            |          |           |          |            |            |            |            |            |            |            |            |            |            |             |       |         |
| LongHistogramRecording           | RyuJit    | .NET Core 2.1        |   934.3 ns | 16.15 ns |  14.32 ns |  3.83 ns |   931.1 ns |   925.6 ns |   941.4 ns |   917.2 ns |   931.1 ns |   938.8 ns |   944.5 ns |   952.5 ns |   958.0 ns |   964.8 ns | 1,070,351.3 |  1.00 |    0.00 |
| LongConcurrentHistogramRecording | RyuJit    | .NET Core 2.1        | 2,839.0 ns | 55.27 ns |  56.76 ns | 13.77 ns | 2,828.6 ns | 2,803.2 ns | 2,898.9 ns | 2,753.3 ns | 2,828.6 ns | 2,872.3 ns | 2,900.8 ns | 2,908.1 ns | 2,915.0 ns | 2,931.4 ns |   352,241.3 |  3.04 |    0.07 |
| IntHistogramRecording            | RyuJit    | .NET Core 2.1        | 1,100.4 ns | 60.57 ns | 177.65 ns | 17.85 ns | 1,044.3 ns |   953.5 ns | 1,205.7 ns |   913.0 ns | 1,044.3 ns | 1,135.7 ns | 1,240.9 ns | 1,375.9 ns | 1,473.2 ns | 1,575.4 ns |   908,761.2 |  1.14 |    0.19 |
| IntConcurrentHistogramRecording  | RyuJit    | .NET Core 2.1        | 2,858.8 ns | 48.34 ns |  45.22 ns | 11.68 ns | 2,852.1 ns | 2,830.5 ns | 2,881.9 ns | 2,790.8 ns | 2,852.1 ns | 2,866.3 ns | 2,895.9 ns | 2,930.0 ns | 2,934.2 ns | 2,934.4 ns |   349,801.0 |  3.06 |    0.05 |
| ShortHistogramRecording          | RyuJit    | .NET Core 2.1        | 1,056.5 ns | 48.42 ns | 139.71 ns | 14.26 ns | 1,030.1 ns |   939.4 ns | 1,131.6 ns |   874.7 ns | 1,030.1 ns | 1,096.5 ns | 1,172.6 ns | 1,285.8 ns | 1,329.1 ns | 1,417.9 ns |   946,542.6 |  1.15 |    0.13 |
| LongRecorderRecording            | RyuJit    | .NET Core 2.1        | 2,018.0 ns | 39.13 ns |  52.24 ns | 10.45 ns | 2,015.3 ns | 1,969.8 ns | 2,042.0 ns | 1,957.1 ns | 2,015.3 ns | 2,037.6 ns | 2,062.0 ns | 2,099.9 ns | 2,112.0 ns | 2,124.0 ns |   495,546.7 |  2.16 |    0.07 |
| LongConcurrentRecorderRecording  | RyuJit    | .NET Core 2.1        | 3,928.3 ns | 68.66 ns |  57.34 ns | 15.90 ns | 3,948.6 ns | 3,878.1 ns | 3,960.3 ns | 3,855.8 ns | 3,948.6 ns | 3,954.5 ns | 3,963.2 ns | 3,967.3 ns | 4,004.4 ns | 4,059.3 ns |   254,564.1 |  4.21 |    0.07 |
| IntRecorderRecording             | RyuJit    | .NET Core 2.1        | 2,028.4 ns | 39.20 ns |  59.86 ns | 10.75 ns | 2,006.8 ns | 1,982.5 ns | 2,081.3 ns | 1,965.7 ns | 2,006.8 ns | 2,041.1 ns | 2,087.0 ns | 2,113.4 ns | 2,117.1 ns | 2,198.3 ns |   492,998.5 |  2.18 |    0.09 |
| IntConcurrentRecorderRecording   | RyuJit    | .NET Core 2.1        | 3,926.3 ns | 76.43 ns | 109.61 ns | 20.71 ns | 3,887.7 ns | 3,833.1 ns | 3,990.7 ns | 3,794.6 ns | 3,887.7 ns | 3,960.4 ns | 4,055.2 ns | 4,110.9 ns | 4,114.9 ns | 4,126.7 ns |   254,690.1 |  4.21 |    0.15 |
| ShortRecorderRecording           | RyuJit    | .NET Core 2.1        | 2,016.7 ns | 39.35 ns |  51.16 ns | 10.44 ns | 2,005.2 ns | 1,975.5 ns | 2,039.2 ns | 1,957.1 ns | 2,005.2 ns | 2,018.5 ns | 2,068.2 ns | 2,089.7 ns | 2,119.4 ns | 2,130.6 ns |   495,866.5 |  2.16 |    0.06 |
|                                  |           |                      |            |          |           |          |            |            |            |            |            |            |            |            |            |            |             |       |         |
| LongHistogramRecording           | RyuJit    | .NET Core 3.1        |   860.9 ns | 17.22 ns |  16.10 ns |  4.16 ns |   860.6 ns |   849.4 ns |   868.6 ns |   840.0 ns |   860.6 ns |   867.2 ns |   870.6 ns |   880.7 ns |   888.3 ns |   895.9 ns | 1,161,568.1 |  1.00 |    0.00 |
| LongConcurrentHistogramRecording | RyuJit    | .NET Core 3.1        | 2,775.3 ns | 51.14 ns |  47.83 ns | 12.35 ns | 2,769.2 ns | 2,738.3 ns | 2,808.3 ns | 2,700.4 ns | 2,769.2 ns | 2,791.7 ns | 2,816.1 ns | 2,841.6 ns | 2,846.5 ns | 2,849.8 ns |   360,324.5 |  3.22 |    0.09 |
| IntHistogramRecording            | RyuJit    | .NET Core 3.1        |   780.3 ns | 15.55 ns |  41.78 ns |  4.56 ns |   769.8 ns |   753.2 ns |   791.6 ns |   734.0 ns |   769.8 ns |   781.0 ns |   799.4 ns |   839.0 ns |   866.6 ns |   937.1 ns | 1,281,559.4 |  0.90 |    0.06 |
| IntConcurrentHistogramRecording  | RyuJit    | .NET Core 3.1        | 2,797.8 ns | 52.85 ns |  56.55 ns | 13.33 ns | 2,791.5 ns | 2,741.1 ns | 2,851.1 ns | 2,724.6 ns | 2,791.5 ns | 2,820.0 ns | 2,856.8 ns | 2,872.2 ns | 2,885.1 ns | 2,887.7 ns |   357,425.5 |  3.25 |    0.09 |
| ShortHistogramRecording          | RyuJit    | .NET Core 3.1        | 1,034.1 ns | 56.87 ns | 165.89 ns | 16.76 ns |   949.8 ns |   907.5 ns | 1,133.8 ns |   873.0 ns |   949.8 ns | 1,102.0 ns | 1,184.8 ns | 1,300.4 ns | 1,356.6 ns | 1,496.7 ns |   966,990.6 |  1.22 |    0.23 |
| LongRecorderRecording            | RyuJit    | .NET Core 3.1        | 2,023.7 ns | 40.41 ns |  82.54 ns | 11.56 ns | 1,997.2 ns | 1,951.6 ns | 2,075.9 ns | 1,928.1 ns | 1,997.2 ns | 2,060.6 ns | 2,094.3 ns | 2,130.4 ns | 2,176.6 ns | 2,242.0 ns |   494,135.5 |  2.44 |    0.10 |
| LongConcurrentRecorderRecording  | RyuJit    | .NET Core 3.1        | 3,997.8 ns | 68.61 ns | 120.17 ns | 19.24 ns | 3,942.2 ns | 3,908.2 ns | 4,049.8 ns | 3,874.2 ns | 3,942.2 ns | 3,995.6 ns | 4,111.0 ns | 4,166.6 ns | 4,203.5 ns | 4,326.9 ns |   250,139.9 |  4.64 |    0.16 |
| IntRecorderRecording             | RyuJit    | .NET Core 3.1        | 1,984.3 ns | 38.30 ns |  42.58 ns |  9.77 ns | 1,979.3 ns | 1,958.2 ns | 2,004.0 ns | 1,915.7 ns | 1,979.3 ns | 1,994.1 ns | 2,010.9 ns | 2,054.8 ns | 2,058.5 ns | 2,061.9 ns |   503,948.9 |  2.31 |    0.06 |
| IntConcurrentRecorderRecording   | RyuJit    | .NET Core 3.1        | 4,003.6 ns | 77.17 ns | 110.67 ns | 20.92 ns | 3,980.5 ns | 3,903.0 ns | 4,087.8 ns | 3,846.6 ns | 3,980.5 ns | 4,042.5 ns | 4,102.8 ns | 4,169.9 ns | 4,186.4 ns | 4,206.6 ns |   249,774.3 |  4.65 |    0.16 |
| ShortRecorderRecording           | RyuJit    | .NET Core 3.1        | 2,140.0 ns | 41.11 ns |  38.45 ns |  9.93 ns | 2,132.7 ns | 2,113.6 ns | 2,156.9 ns | 2,097.6 ns | 2,132.7 ns | 2,139.4 ns | 2,175.0 ns | 2,201.4 ns | 2,212.1 ns | 2,214.3 ns |   467,287.4 |  2.49 |    0.07 |

// * Warnings *
MultimodalDistribution
  Recording32BitBenchmark.IntHistogramRecording: Jit=LegacyJit, Runtime=.NET Framework 4.8.1          -> It seems that the distribution is bimodal (mValue = 3.21)
  Recording32BitBenchmark.LongRecorderRecording: Jit=LegacyJit, Runtime=.NET Framework 4.8.1          -> It seems that the distribution can have several modes (mValue = 3)
  Recording32BitBenchmark.IntConcurrentRecorderRecording: Jit=LegacyJit, Runtime=.NET Framework 4.8.1 -> It seems that the distribution can have several modes (mValue = 2.82)
  Recording32BitBenchmark.IntHistogramRecording: Runtime=.NET 6.0                                     -> It seems that the distribution can have several modes (mValue = 2.87)
  Recording32BitBenchmark.IntHistogramRecording: Runtime=.NET 8.0                                     -> It seems that the distribution can have several modes (mValue = 2.94)
  Recording32BitBenchmark.ShortHistogramRecording: Runtime=.NET Core 2.1                              -> It seems that the distribution is bimodal (mValue = 3.45)

// * Hints *
Outliers
  Recording32BitBenchmark.LongConcurrentHistogramRecording: Jit=LegacyJit, Runtime=.NET Framework 4.8.1 -> 4 outliers were removed (3.20 us..3.56 us)
  Recording32BitBenchmark.IntHistogramRecording: Jit=LegacyJit, Runtime=.NET Framework 4.8.1            -> 3 outliers were removed (1.44 us..1.61 us)
  Recording32BitBenchmark.ShortHistogramRecording: Jit=LegacyJit, Runtime=.NET Framework 4.8.1          -> 7 outliers were removed (1.17 us..1.36 us)
  Recording32BitBenchmark.IntConcurrentRecorderRecording: Jit=LegacyJit, Runtime=.NET Framework 4.8.1   -> 1 outlier  was  removed (6.20 us)
  Recording32BitBenchmark.ShortRecorderRecording: Jit=LegacyJit, Runtime=.NET Framework 4.8.1           -> 2 outliers were removed (2.31 us, 2.39 us)
  Recording32BitBenchmark.LongConcurrentHistogramRecording: Jit=RyuJit, Runtime=.NET Framework 4.8.1    -> 1 outlier  was  removed (3.45 us)
  Recording32BitBenchmark.IntHistogramRecording: Jit=RyuJit, Runtime=.NET Framework 4.8.1               -> 6 outliers were removed (1.05 us..1.30 us)
  Recording32BitBenchmark.ShortHistogramRecording: Jit=RyuJit, Runtime=.NET Framework 4.8.1             -> 1 outlier  was  removed (877.32 ns)
  Recording32BitBenchmark.LongRecorderRecording: Jit=RyuJit, Runtime=.NET Framework 4.8.1               -> 1 outlier  was  removed (2.36 us)
  Recording32BitBenchmark.IntConcurrentRecorderRecording: Jit=RyuJit, Runtime=.NET Framework 4.8.1      -> 1 outlier  was  removed (4.31 us)
  Recording32BitBenchmark.ShortRecorderRecording: Jit=RyuJit, Runtime=.NET Framework 4.8.1              -> 1 outlier  was  removed (2.21 us)
  Recording32BitBenchmark.LongHistogramRecording: Runtime=.NET 5.0                                      -> 2 outliers were removed (894.30 ns, 913.61 ns)
  Recording32BitBenchmark.IntHistogramRecording: Runtime=.NET 5.0                                       -> 11 outliers were removed (1.13 us..1.34 us)
  Recording32BitBenchmark.IntConcurrentHistogramRecording: Runtime=.NET 5.0                             -> 2 outliers were removed (3.02 us, 3.06 us)
  Recording32BitBenchmark.ShortHistogramRecording: Runtime=.NET 5.0                                     -> 7 outliers were removed (1.26 us..1.38 us)
  Recording32BitBenchmark.LongRecorderRecording: Runtime=.NET 5.0                                       -> 1 outlier  was  removed (2.26 us)
  Recording32BitBenchmark.LongConcurrentRecorderRecording: Runtime=.NET 5.0                             -> 1 outlier  was  removed (4.59 us)
  Recording32BitBenchmark.IntConcurrentRecorderRecording: Runtime=.NET 5.0                              -> 3 outliers were removed (4.47 us..11.81 us)
  Recording32BitBenchmark.ShortRecorderRecording: Runtime=.NET 5.0                                      -> 2 outliers were removed (2.10 us, 2.14 us)
  Recording32BitBenchmark.LongHistogramRecording: Runtime=.NET 6.0                                      -> 2 outliers were removed (793.07 ns, 824.38 ns)
  Recording32BitBenchmark.IntHistogramRecording: Runtime=.NET 6.0                                       -> 5 outliers were removed (1.05 us..1.63 us)
  Recording32BitBenchmark.ShortHistogramRecording: Runtime=.NET 6.0                                     -> 8 outliers were removed (1.08 us..1.35 us)
  Recording32BitBenchmark.LongHistogramRecording: Runtime=.NET 7.0                                      -> 3 outliers were removed (728.79 ns..763.69 ns)
  Recording32BitBenchmark.IntHistogramRecording: Runtime=.NET 7.0                                       -> 7 outliers were removed (1.00 us..1.18 us)
  Recording32BitBenchmark.IntConcurrentHistogramRecording: Runtime=.NET 7.0                             -> 1 outlier  was  removed (2.88 us)
  Recording32BitBenchmark.ShortHistogramRecording: Runtime=.NET 7.0                                     -> 3 outliers were removed (1.10 us..1.16 us)
  Recording32BitBenchmark.IntConcurrentRecorderRecording: Runtime=.NET 7.0                              -> 1 outlier  was  removed (4.27 us)
  Recording32BitBenchmark.IntHistogramRecording: Runtime=.NET 8.0                                       -> 3 outliers were removed (759.01 ns..1.06 us)
  Recording32BitBenchmark.ShortHistogramRecording: Runtime=.NET 8.0                                     -> 5 outliers were removed (572.40 ns..623.05 ns)
  Recording32BitBenchmark.ShortRecorderRecording: Runtime=.NET 8.0                                      -> 2 outliers were removed (1.76 us, 1.79 us)
  Recording32BitBenchmark.LongHistogramRecording: Runtime=.NET Core 2.1                                 -> 1 outlier  was  removed (992.45 ns)
  Recording32BitBenchmark.IntHistogramRecording: Runtime=.NET Core 2.1                                  -> 1 outlier  was  removed (1.85 us)
  Recording32BitBenchmark.ShortHistogramRecording: Runtime=.NET Core 2.1                                -> 4 outliers were removed (1.47 us..1.53 us)
  Recording32BitBenchmark.LongRecorderRecording: Runtime=.NET Core 2.1                                  -> 3 outliers were removed (2.38 us..2.60 us)
  Recording32BitBenchmark.LongConcurrentRecorderRecording: Runtime=.NET Core 2.1                        -> 2 outliers were removed (4.15 us, 4.37 us)
  Recording32BitBenchmark.ShortRecorderRecording: Runtime=.NET Core 2.1                                 -> 2 outliers were removed (2.34 us, 2.35 us)
  Recording32BitBenchmark.IntHistogramRecording: Runtime=.NET Core 3.1                                  -> 16 outliers were removed (963.14 ns..1.31 us)
  Recording32BitBenchmark.ShortHistogramRecording: Runtime=.NET Core 3.1                                -> 2 outliers were removed (1.53 us, 1.91 us)
  Recording32BitBenchmark.LongRecorderRecording: Runtime=.NET Core 3.1                                  -> 1 outlier  was  removed (2.38 us)
  Recording32BitBenchmark.LongConcurrentRecorderRecording: Runtime=.NET Core 3.1                        -> 3 outliers were removed (4.48 us..4.56 us)
  Recording32BitBenchmark.IntRecorderRecording: Runtime=.NET Core 3.1                                   -> 1 outlier  was  removed (2.19 us)
  Recording32BitBenchmark.IntConcurrentRecorderRecording: Runtime=.NET Core 3.1                         -> 1 outlier  was  removed (4.48 us)

// * Legends *
  Mean    : Arithmetic mean of all measurements
  Error   : Half of 99.9% confidence interval
  StdDev  : Standard deviation of all measurements
  StdErr  : Standard error of all measurements
  Median  : Value separating the higher half of all measurements (50th percentile)
  Q1      : Quartile 1 (25th percentile)
  Q3      : Quartile 3 (75th percentile)
  P0      : Percentile 0
  P50     : Percentile 50
  P67     : Percentile 67
  P80     : Percentile 80
  P90     : Percentile 90
  P95     : Percentile 95
  P100    : Percentile 100
  Op/s    : Operation per second
  Ratio   : Mean of the ratio distribution ([Current]/[Baseline])
  1 ns    : 1 Nanosecond (0.000000001 sec)

// ***** BenchmarkRunner: End *****
Run time: 00:47:40 (2860.59 sec), executed benchmarks: 80

Global total time: 03:00:41 (10841.45 sec), executed benchmarks: 256
```