### PR TITLE
Hygiene update for Unit tests

### DIFF
--- a/HdrHistogram.UnitTests/HdrHistogram.UnitTests.csproj
+++ b/HdrHistogram.UnitTests/HdrHistogram.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1.29</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HdrHistogram.UnitTests/HdrHistogram.UnitTests.csproj
+++ b/HdrHistogram.UnitTests/HdrHistogram.UnitTests.csproj
@@ -83,7 +83,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="4.19.2" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.2" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.6.24" />

--- a/HdrHistogram.UnitTests/HdrHistogram.UnitTests.csproj
+++ b/HdrHistogram.UnitTests/HdrHistogram.UnitTests.csproj
@@ -85,7 +85,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.2" />
-    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.2.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/HdrHistogram.UnitTests/HdrHistogram.UnitTests.csproj
+++ b/HdrHistogram.UnitTests/HdrHistogram.UnitTests.csproj
@@ -86,7 +86,7 @@
     <PackageReference Include="FluentAssertions" Version="4.19.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.2" />
     <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="Xunit.Combinatorial" Version="1.2.1" />
+    <PackageReference Include="Xunit.Combinatorial" Version="1.6.24" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
 

--- a/HdrHistogram.UnitTests/HistogramFactoryTests.cs
+++ b/HdrHistogram.UnitTests/HistogramFactoryTests.cs
@@ -162,6 +162,7 @@ namespace HdrHistogram.UnitTests
             Assert.IsAssignableFrom<LongConcurrentHistogram>(actual);
         }
 
+        [Theory]
         [InlineData(1, 5000, 3)]
         [InlineData(1000, 100000, 5)]
         public void CanCreateLongHistogramWithSpecifiedRangeValues(long min, long max, int sf)
@@ -176,6 +177,8 @@ namespace HdrHistogram.UnitTests
             Assert.Equal(max, actual.HighestTrackableValue);
             Assert.Equal(sf, actual.NumberOfSignificantValueDigits);
         }
+
+        [Theory]
         [InlineData(1, 5000, 3)]
         [InlineData(1000, 100000, 5)]
         public void LongConcurrentHistogramWithSpecifiedRangeValues(long min, long max, int sf)
@@ -192,6 +195,7 @@ namespace HdrHistogram.UnitTests
             Assert.Equal(sf, actual.NumberOfSignificantValueDigits);
         }
 
+        [Theory]
         [InlineData(1, 5000, 3)]
         [InlineData(1000, 100000, 5)]
         public void CanCreateLongHistogramRecorder(long min, long max, int sf)
@@ -209,6 +213,7 @@ namespace HdrHistogram.UnitTests
             Assert.Equal(sf, histogram.NumberOfSignificantValueDigits);
         }
 
+        [Theory]
         [InlineData(1, 5000, 3)]
         [InlineData(1000, 100000, 5)]
         public void CanCreateLongConcurrentHistogramRecorder(long min, long max, int sf)

--- a/HdrHistogram.UnitTests/HistogramTestBase.cs
+++ b/HdrHistogram.UnitTests/HistogramTestBase.cs
@@ -357,7 +357,6 @@ namespace HdrHistogram.UnitTests
         [InlineData("\r")]
         [InlineData("\n")]
         [InlineData(" ")]
-        [InlineData(" ")]
         public void Setting_invalid_value_to_Tag_throws(string invalidTagValue)
         {
             var histogram = Create(DefaultHighestTrackableValue, DefaultSignificantFigures);

--- a/HdrHistogram.UnitTests/Persistence/HistogramLogReaderWriterTestBase.cs
+++ b/HdrHistogram.UnitTests/Persistence/HistogramLogReaderWriterTestBase.cs
@@ -49,7 +49,7 @@ namespace HdrHistogram.UnitTests.Persistence
             var data = histogram.WriteLog();
             var actualHistograms = data.ReadHistograms();
 
-            Assert.Equal(1, actualHistograms.Length);
+            Assert.Single(actualHistograms);
             HistogramAssert.AreValueEqual(histogram, actualHistograms.Single());
         }
 
@@ -63,7 +63,7 @@ namespace HdrHistogram.UnitTests.Persistence
             var data = histogram.WriteLog();
             var actualHistograms = data.ReadHistograms();
 
-            Assert.Equal(1, actualHistograms.Length);
+            Assert.Single(actualHistograms);
             HistogramAssert.AreValueEqual(histogram, actualHistograms.Single());
         }
 
@@ -81,7 +81,7 @@ namespace HdrHistogram.UnitTests.Persistence
             var data = histogram.WriteLog();
             var actualHistograms = data.ReadHistograms();
 
-            Assert.Equal(1, actualHistograms.Length);
+            Assert.Single(actualHistograms);
             Assert.Equal(tag, actualHistograms[0].Tag);
             HistogramAssert.AreValueEqual(histogram, actualHistograms.Single());
         }


### PR DESCRIPTION

 - `Assert.Equal(1, actualHistograms.Length)` to `Assert.Single(actualHistograms)`
 - Add missing `[Theory]` on 4 tests
 - Removed duplicate`[InlineData(" ")]` on `Setting_invalid_value_to_Tag_throws` test
 - xunit from v2.2.0 to v2.9.0
 - Xunit.Combinatorial from v1.2.1 to v1.6.24
 - FluentAssertions from v4.19.2 to v6.12.0