### PR TITLE
Closing streams before returning them

### DIFF
--- a/HdrHistogram.UnitTests/Persistence/HistogramLogExtensions.cs
+++ b/HdrHistogram.UnitTests/Persistence/HistogramLogExtensions.cs
@@ -9,12 +9,10 @@ namespace HdrHistogram.UnitTests.Persistence
     {
         public static HistogramBase[] ReadHistograms(this byte[] data)
         {
-            HistogramBase[] actualHistograms;
             using (var readerStream = new MemoryStream(data))
             {
-                actualHistograms = HistogramLogReader.Read(readerStream).ToArray();
+                return HistogramLogReader.Read(readerStream).ToArray();
             }
-            return actualHistograms;
         }
 
         public static byte[] WriteLog(this HistogramBase histogram)

--- a/HdrHistogram/HistogramLogReader.cs
+++ b/HdrHistogram/HistogramLogReader.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using HdrHistogram.Utilities;
 
@@ -29,7 +30,8 @@ namespace HdrHistogram
         {
             using (var reader = new HistogramLogReader(inputStream))
             {
-                return reader.ReadHistograms();
+                return reader.ReadHistograms()
+                    .ToArray();
             }
         }
 


### PR DESCRIPTION
Since .netcoreapp3/net5 these streams are causing errors when used after disposed.