### PR TITLE
Adding Intrinsic LZC support

### DIFF
--- a/HdrHistogram.Benchmarking/LeadingZeroCount/LeadingZeroCountBenchmarkBase.cs
+++ b/HdrHistogram.Benchmarking/LeadingZeroCount/LeadingZeroCountBenchmarkBase.cs
@@ -27,17 +27,19 @@ namespace HdrHistogram.Benchmarking.LeadingZeroCount
     /// </remarks>
     public abstract class LeadingZeroCountBenchmarkBase
     {
+        private const int TEST_VALUE_LENGTH = 92;
         private readonly int _maxBit;
         private readonly long[] _testValues;
 
         protected LeadingZeroCountBenchmarkBase(int maxBit)
         {
             _maxBit = maxBit;
-            
 
             //Create array of +ve numbers in the 'maxBit' bit range (i.e. 32 bit or 64bit)
             var expectedData = GenerateTestData(maxBit);
             _testValues = expectedData.Select(d => d.Value).ToArray();
+
+            if (_testValues.Length != TEST_VALUE_LENGTH) throw new System.InvalidOperationException($"Constant TEST_VALUE_LENGTH has incorrect value of {TEST_VALUE_LENGTH}. Expected {_testValues.Length}.");
         }
 
         [BenchmarkDotNet.Attributes.GlobalSetup]
@@ -47,6 +49,7 @@ namespace HdrHistogram.Benchmarking.LeadingZeroCount
             var functions = new Dictionary<string, Func<long, int>>
             {
                 {"CurrentImpl", Bitwise.NumberOfLeadingZeros},
+                {"Imperative", Bitwise.Imperative.NumberOfLeadingZeros},
                 {"IfAndShift", LeadingZeroCount.IfAndShift.GetLeadingZeroCount},
                 //{"MathLog", LeadingZeroCount.MathLog.GetLeadingZeroCount},
                 {"StringManipulation", LeadingZeroCount.StringManipulation.GetLeadingZeroCount},
@@ -61,7 +64,7 @@ namespace HdrHistogram.Benchmarking.LeadingZeroCount
             };
             ValidateImplementations(expectedData, functions);
         }
-        
+
         private static CalculationExpectation[] GenerateTestData(int maxBit)
         {
             //Create array of +ve numbers in the 'maxBit' bit range (i.e. 32 bit or 64bit)
@@ -101,10 +104,9 @@ namespace HdrHistogram.Benchmarking.LeadingZeroCount
                 }
             }
         }
-        
-        
 
-        [Benchmark(Baseline = true)]
+
+        [Benchmark(Baseline = true, OperationsPerInvoke = TEST_VALUE_LENGTH)]
         public int CurrentImplementation()
         {
             var sum = 0;
@@ -115,7 +117,18 @@ namespace HdrHistogram.Benchmarking.LeadingZeroCount
             return sum;
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = TEST_VALUE_LENGTH)]
+        public int ImperativeImplementation()
+        {
+            var sum = 0;
+            for (int i = 0; i < _testValues.Length; i++)
+            {
+                sum += Bitwise.Imperative.NumberOfLeadingZeros(_testValues[i]);
+            }
+            return sum;
+        }
+
+        [Benchmark(OperationsPerInvoke = TEST_VALUE_LENGTH)]
         public int IfAndShift()
         {
             var sum = 0;
@@ -126,7 +139,7 @@ namespace HdrHistogram.Benchmarking.LeadingZeroCount
             return sum;
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = TEST_VALUE_LENGTH)]
         public int DeBruijnMultiplication()
         {
             var sum = 0;
@@ -137,7 +150,7 @@ namespace HdrHistogram.Benchmarking.LeadingZeroCount
             return sum;
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = TEST_VALUE_LENGTH)]
         public int Debruijn64Bit()
         {
             var sum = 0;
@@ -148,7 +161,7 @@ namespace HdrHistogram.Benchmarking.LeadingZeroCount
             return sum;
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = TEST_VALUE_LENGTH)]
         public int DeBruijn64BitsBitScanner()
         {
             var sum = 0;
@@ -159,7 +172,7 @@ namespace HdrHistogram.Benchmarking.LeadingZeroCount
             return sum;
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = TEST_VALUE_LENGTH)]
         public int Debruijn128Bit()
         {
             var sum = 0;
@@ -170,7 +183,7 @@ namespace HdrHistogram.Benchmarking.LeadingZeroCount
             return sum;
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = TEST_VALUE_LENGTH)]
         public int StringManipulation()
         {
             var sum = 0;
@@ -180,7 +193,7 @@ namespace HdrHistogram.Benchmarking.LeadingZeroCount
             }
             return sum;
         }
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = TEST_VALUE_LENGTH)]
         public int BBarry_imp1()
         {
             var sum = 0;
@@ -190,7 +203,7 @@ namespace HdrHistogram.Benchmarking.LeadingZeroCount
             }
             return sum;
         }
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = TEST_VALUE_LENGTH)]
         public int BBarry_imp2()
         {
             var sum = 0;
@@ -200,7 +213,7 @@ namespace HdrHistogram.Benchmarking.LeadingZeroCount
             }
             return sum;
         }
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = TEST_VALUE_LENGTH)]
         public int BBarry_imp3()
         {
             var sum = 0;
@@ -210,7 +223,7 @@ namespace HdrHistogram.Benchmarking.LeadingZeroCount
             }
             return sum;
         }
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = TEST_VALUE_LENGTH)]
         public int BBarry_imp4()
         {
             var sum = 0;

--- a/HdrHistogram/Utilities/Bitwise.cs
+++ b/HdrHistogram/Utilities/Bitwise.cs
@@ -8,33 +8,13 @@
 
 using System;
 
-
 namespace HdrHistogram.Utilities
 {
-    //Code has been tested and taken from :
-    //http://stackoverflow.com/questions/9543410/i-dont-think-numberofleadingzeroslong-i-in-long-java-is-based-floorlog2x/9543537#9543537
-    //http://stackoverflow.com/questions/21888140/de-bruijn-algorithm-binary-digit-count-64bits-c-sharp/21888542#21888542
-    //http://stackoverflow.com/questions/15967240/fastest-implementation-of-log2int-and-log2float
-    //http://graphics.stanford.edu/~seander/bithacks.html#IntegerLogObvious
-    //
-    //Ideally newer versions of .NET will expose the CPU instructions to do this  Intel SSE 'lzcnt' (Leading Zero Count), or give access to the BitScanReverse VC++ functions (https://msdn.microsoft.com/en-us/library/fbxyd7zd.aspx)
-
     /// <summary>
     /// Exposes optimised methods to get Leading Zero Count.
     /// </summary>
     public static class Bitwise
     {
-        private static readonly int[] Lookup;
-
-        static Bitwise()
-        {
-            Lookup = new int[256];
-            for (int i = 1; i < 256; ++i)
-            {
-                Lookup[i] = (int)(Math.Log(i) / Math.Log(2));
-            }
-        }
-
         /// <summary>
         /// Returns the Leading Zero Count (lzc) of the <paramref name="value"/> for its binary representation.
         /// </summary>
@@ -42,39 +22,88 @@ namespace HdrHistogram.Utilities
         /// <returns>The number of leading zeros.</returns>
         public static int NumberOfLeadingZeros(long value)
         {
-            //Optimisation for 32 bit values. So values under 00:16:41.0 when measuring with Stopwatch.GetTimestamp()*, we will hit a fast path.
-            //  * as at writing on Win10 .NET 4.6
-            if (value < int.MaxValue)
-                return 63 - Log2((int)value);
-            return NumberOfLeadingZerosLong(value);
+#if NET5_0_OR_GREATER
+            return Intrinsic.NumberOfLeadingZeros(value);
+#else
+            return Imperative.NumberOfLeadingZeros(value);
+#endif
         }
 
-        private static int NumberOfLeadingZerosLong(long value)
+#if NET5_0_OR_GREATER
+        public static class Intrinsic
         {
-            // Code from http://stackoverflow.com/questions/9543410/i-dont-think-numberofleadingzeroslong-i-in-long-java-is-based-floorlog2x/9543537#9543537
+            public static int NumberOfLeadingZeros(long value)
+            {
+                ulong testValue = (ulong)value;
+                return System.Numerics.BitOperations.LeadingZeroCount(testValue);
 
-            //--Already checked that values here are over int.MaxValue, i.e. !=0
-            // HD, Figure 5-6
-            //if (value == 0)
-            //    return 64;
-            var n = 1;
-            // >>> in Java is a "unsigned bit shift", to do the same in C# we use >> (but it HAS to be an unsigned int)
-            var x = (uint)(value >> 32);
-            if (x == 0) { n += 32; x = (uint)value; }
-            if (x >> 16 == 0) { n += 16; x <<= 16; }
-            if (x >> 24 == 0) { n += 8; x <<= 8; }
-            if (x >> 28 == 0) { n += 4; x <<= 4; }
-            if (x >> 30 == 0) { n += 2; x <<= 2; }
-            n -= (int)(x >> 31);
-            return n;
+            }
         }
+#endif
 
-        private static int Log2(int i)
+        //Code has been tested and taken from :
+        //http://stackoverflow.com/questions/9543410/i-dont-think-numberofleadingzeroslong-i-in-long-java-is-based-floorlog2x/9543537#9543537
+        //http://stackoverflow.com/questions/21888140/de-bruijn-algorithm-binary-digit-count-64bits-c-sharp/21888542#21888542
+        //http://stackoverflow.com/questions/15967240/fastest-implementation-of-log2int-and-log2float
+        //http://graphics.stanford.edu/~seander/bithacks.html#IntegerLogObvious
+
+        /// <summary>
+        /// Imperative implementation of the LeadingZeroCount, when access to the BitOperations.LeadingZeroCount is not available.
+        /// </summary>
+        public static class Imperative
         {
-            if (i >= 0x1000000) { return Lookup[i >> 24] + 24; }
-            if (i >= 0x10000) { return Lookup[i >> 16] + 16; }
-            if (i >= 0x100) { return Lookup[i >> 8] + 8; }
-            return Lookup[i];
+            private static readonly int[] Lookup;
+
+            static Imperative()
+            {
+                Lookup = new int[256];
+                for (int i = 1; i < 256; ++i)
+                {
+                    Lookup[i] = (int)(Math.Log(i) / Math.Log(2));
+                }
+            }
+
+            /// <summary>
+            /// Returns the Leading Zero Count (lzc) of the <paramref name="value"/> for its binary representation.
+            /// </summary>
+            /// <param name="value">The value to find the number of leading zeros</param>
+            /// <returns>The number of leading zeros.</returns>
+            public static int NumberOfLeadingZeros(long value)
+            {
+                //Optimisation for 32 bit values. So values under 00:16:41.0 when measuring with Stopwatch.GetTimestamp()*, we will hit a fast path.
+                //  * as at writing on Win10 .NET 4.6
+                if (value < int.MaxValue)
+                    return 63 - Log2((int)value);
+                return NumberOfLeadingZerosLong(value);
+            }
+
+            private static int NumberOfLeadingZerosLong(long value)
+            {
+                // Code from http://stackoverflow.com/questions/9543410/i-dont-think-numberofleadingzeroslong-i-in-long-java-is-based-floorlog2x/9543537#9543537
+
+                //--Already checked that values here are over int.MaxValue, i.e. !=0
+                // HD, Figure 5-6
+                //if (value == 0)
+                //    return 64;
+                var n = 1;
+                // >>> in Java is a "unsigned bit shift", to do the same in C# we use >> (but it HAS to be an unsigned int)
+                var x = (uint)(value >> 32);
+                if (x == 0) { n += 32; x = (uint)value; }
+                if (x >> 16 == 0) { n += 16; x <<= 16; }
+                if (x >> 24 == 0) { n += 8; x <<= 8; }
+                if (x >> 28 == 0) { n += 4; x <<= 4; }
+                if (x >> 30 == 0) { n += 2; x <<= 2; }
+                n -= (int)(x >> 31);
+                return n;
+            }
+
+            private static int Log2(int i)
+            {
+                if (i >= 0x1000000) { return Lookup[i >> 24] + 24; }
+                if (i >= 0x10000) { return Lookup[i >> 16] + 16; }
+                if (i >= 0x100) { return Lookup[i >> 8] + 8; }
+                return Lookup[i];
+            }
         }
     }
 }


### PR DESCRIPTION

 - Adding support for using intrinsic CPU level instruction of LeadingZeroCount (LZC)
 - Provides the operation count for each benchmark to get a more accurate operations-per-second measurement in benchmark testing
 - Pushes implementation to two nested classes within `HdrHistogram.Utilities.Bitwise` named `Intrinsic` and `Imperative`, where `Imperative` is the existing logic.

Closes #42 

# Performance improvements

This introduces a significant performance increase of approximately 2.5x increase in operations per second. 
The performance improvements in .NET 8.0 runtime have a significant impact, but the primary performance boost is from using the "LZC" (Leading Zero Count) CPU Level instruction.

## LongHistogram performance by runtime

The evolution of the performance improvements by runtime can be seen here. 
Note that each improvement until .NET 7.0 is just "free speed" each time we upgrade the runtime (no code changes required).
![image](https://github.com/user-attachments/assets/88bc32d4-383d-46e3-86d1-7c8d0e8be56a)

(and in ops/second if you like "up and to the right" charts)
![image](https://github.com/user-attachments/assets/3d821ed3-b54d-42ce-91a7-7566afb7b792)

### Supporting raw data

|Platform | Platform Release date | Mean (ns) | ops/sec|
|-- | --: | --: | --:
|net 4.8.1 (legacy) | 5-Apr-17 | 3.949 | 253,245,268
|net 4.8.1 (Ryu) | 5-Apr-17 | 3.975 | 251,576,208
|core 2.1 | 30-May-18 | 4.332 | 230,816,584
|core 3.1 | 3-Dec-19 | 3.956 | 252,782,221
|net 5.0 | 10-Nov-20 | 4.080 | 245,114,256
|net 6.0 | 8-Nov-21 | 3.539 | 282,534,444
|net 7.0 | 8-Nov-22 | 3.598 | 277,923,552
|net 8.0 | 14-Nov-23 | 1.430 | 699,483,028

## Leading Zero Count performance by runtime

The performance comparisons in each runtime's LeadingZeroCount execution explain the significant change in .NET 8.0's performance improvement.
The first chart shows improvements for 32-bit values of 64-bit numbers, and the second is for 64-bit values.
Note that there are two .NET 8.0 values: one for the NET8.0 runtime improvement with no code change and the other for using the intrinsic CPU-level instruction of LeadingZeroCount (LZC).

### 32bit values

![image](https://github.com/user-attachments/assets/a45f9a8f-8d31-421a-89d0-6e84234d5df4)



|Platform | Platform Release date | Mean (ns) | ops/sec
|-- | --: | --: | --:
net 4.8.1 (legacy) | 5-Apr-17 | 1.6788 | 595,672,968
net 4.8.1 (Ryu) | 5-Apr-17 | 1.6755 | 596,824,214
core 2.1 | 30-May-18 | 1.6821 | 594,507,181
core 3.1 | 3-Dec-19 | 1.6692 | 599,080,274
net 5.0 | 10-Nov-20 | 1.6422 | 608,924,635
net 6.0 | 8-Nov-21 | 1.6675 | 599,701,979
net 7.0 | 8-Nov-22 | 1.6018 | 624,295,561
net 8.0 | 14-Nov-23 | 1.2026 | 831,551,202
net 8.0 (Intrinsic) | 14-Nov-23 | 0.4168 | 2,399,068,395


### 64bit values

![image](https://github.com/user-attachments/assets/8c86e3bd-36dd-4954-8d9c-89e97f5e9594)


|Platform | Platform Release date | Mean | ops/sec
|-- | --: | --: | --:
net 4.8.1 (legacy) | 5-Apr-17 | 2.1775 | 459,249,563
net 4.8.1 (Ryu) | 5-Apr-17 | 2.2287 | 448,702,040
core 2.1 | 30-May-18 | 1.9334 | 517,230,395
core 3.1 | 3-Dec-19 | 2.2260 | 449,103,487
net 5.0 | 10-Nov-20 | 2.2208 | 450,297,525
net 6.0 | 8-Nov-21 | 2.2248 | 449,480,730
net 7.0 | 8-Nov-22 | 2.3485 | 425,805,413
net 8.0 | 14-Nov-23 | 1.6549 | 604,263,273
net 8.0 (Intrinsic) | 14-Nov-23 | 0.4234 | 2,361,590,954


## NET 8.0 performance by Histogram instance

It is worth noting that the improvements are only significant in the basic histogram instance types.
Concurrent types and the Recorders do not see the same significant improvements.
It is worth noting that while the `LongHistogram`, `IntHistogram`, and `ShortHistogram` had similar performance characteristics previously, in NET 8.0, the smaller types show just under 10% and 20% improvements in operations per second, respectively.

![image](https://github.com/user-attachments/assets/f2f48c4c-a14c-4a46-ad46-98dad010956f)


Instance type | Mean (ns) | ops/sec
-- | --: | --:
LongConcurrentRecorder | 26.596 | 37,599,926
IntConcurrentRecorder | 25.957 | 38,525,243
LongConcurrentHistogram | 22.197 | 45,050,510
IntConcurrentHistogram | 17.237 | 58,015,437
LongRecorder | 10.623 | 94,133,157
IntRecorder | 10.623 | 94,139,595
ShortRecorder | 10.392 | 96,227,000
LongHistogram | 1.430 | 699,483,028
IntHistogram | 1.313 | 761,705,968
ShortHistogram | 1.206 | 829,505,103
