### PR TITLE
Update .gitignore and Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,7 +40,6 @@
       "Bash(git commit:*)",
       "Bash(git commit -m *)",
       "Bash(git push:*)",
-      "Bash(gh pr create:*)",
       "Bash(git config:*)",
       "Bash(git diff:*)",
       "Bash(git fetch:*)",
@@ -104,7 +103,9 @@
     ],
     "deny": [
       "Bash(git branch -D:*)",
-      "Bash(gh pr merge:*)"
+      "Bash(gh pr merge:*)",
+      "Bash(git -C *)",
+      "Bash(cd *)"
     ],
     "ask": []
   }

--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,5 @@ Backup*/
 UpgradeLog*.XML
 
 Thumbs.db
+
+.env


### PR DESCRIPTION
## Summary

- Add `.env` to `.gitignore` to prevent accidentally committing secrets
- Remove `gh pr create` from auto-allow in Claude Code settings (should require confirmation)
- Add `git -C` and `cd` to deny list to enforce sandbox boundaries

## Test plan

- [ ] Verify `.env` files are ignored by git
- [ ] Verify Claude Code prompts before creating PRs
- [ ] Verify `git -C` and `cd` commands are blocked in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)