### PR TITLE
fix: remove external jq dependency from fleet.sh

### DIFF
--- a/.devcontainer/fleet.sh
+++ b/.devcontainer/fleet.sh
@@ -9,30 +9,44 @@ source "$SCRIPT_DIR/.env"
 # Build the image
 docker build -t hdrhistogram-agent -f "$SCRIPT_DIR/Dockerfile" "$SCRIPT_DIR/"
 
-# Fetch available issues (assigned to agent first, then labelled 'agent')
-ISSUES=$(GH_TOKEN="$GH_TOKEN_UPSTREAM" gh issue list --assignee "$GIT_USER_NAME" --state open \
+# Fetch assigned issues as tab-separated "number\ttitle" lines
+ASSIGNED=$(GH_TOKEN="$GH_TOKEN_UPSTREAM" gh issue list --assignee "$GIT_USER_NAME" --state open \
     --repo "$UPSTREAM_REPO" --json number,title --limit "$FLEET_SIZE" \
-    --search "sort:created-asc" 2>/dev/null || echo "[]")
+    --search "sort:created-asc" \
+    --jq '.[] | [.number, .title] | @tsv' 2>/dev/null || true)
 
-ISSUE_COUNT=$(echo "$ISSUES" | jq 'length')
+declare -a ISSUE_NUMS=()
+declare -a ISSUE_TITLES=()
+ASSIGNED_NUMS=""
+
+while IFS=$'\t' read -r num title; do
+    [ -z "$num" ] && continue
+    ISSUE_NUMS+=("$num")
+    ISSUE_TITLES+=("$title")
+    ASSIGNED_NUMS+=" $num "
+done <<< "$ASSIGNED"
+
+ISSUE_COUNT=${#ISSUE_NUMS[@]}
 
 if [ "$ISSUE_COUNT" -lt "$FLEET_SIZE" ]; then
     REMAINING=$((FLEET_SIZE - ISSUE_COUNT))
-    ASSIGNED_NUMS=$(echo "$ISSUES" | jq -r '.[].number')
-
     EXTRA=$(GH_TOKEN="$GH_TOKEN_UPSTREAM" gh issue list --label agent --state open \
         --repo "$UPSTREAM_REPO" --json number,title --limit "$REMAINING" \
-        --search "sort:created-asc" 2>/dev/null || echo "[]")
+        --search "sort:created-asc" \
+        --jq '.[] | [.number, .title] | @tsv' 2>/dev/null || true)
 
-    # Filter out any already-assigned issues
-    for num in $ASSIGNED_NUMS; do
-        EXTRA=$(echo "$EXTRA" | jq --argjson n "$num" '[.[] | select(.number != $n)]')
-    done
-
-    ISSUES=$(echo "$ISSUES $EXTRA" | jq -s 'add // []')
+    while IFS=$'\t' read -r num title; do
+        [ -z "$num" ] && continue
+        # Skip already-assigned issues
+        if [[ "$ASSIGNED_NUMS" == *" $num "* ]]; then
+            continue
+        fi
+        ISSUE_NUMS+=("$num")
+        ISSUE_TITLES+=("$title")
+    done <<< "$EXTRA"
 fi
 
-ISSUE_COUNT=$(echo "$ISSUES" | jq 'length')
+ISSUE_COUNT=${#ISSUE_NUMS[@]}
 if [ "$ISSUE_COUNT" -eq 0 ]; then
     echo "No issues available."
     exit 0
@@ -41,8 +55,8 @@ fi
 echo "Found $ISSUE_COUNT issue(s). Launching agents..."
 
 for i in $(seq 0 $((ISSUE_COUNT - 1))); do
-    ISSUE_NUM=$(echo "$ISSUES" | jq -r ".[$i].number")
-    ISSUE_TITLE=$(echo "$ISSUES" | jq -r ".[$i].title")
+    ISSUE_NUM="${ISSUE_NUMS[$i]}"
+    ISSUE_TITLE="${ISSUE_TITLES[$i]}"
     AGENT_NAME="hdrhistogram-agent-${ISSUE_NUM}"
 
     echo "Starting $AGENT_NAME for issue #${ISSUE_NUM}: ${ISSUE_TITLE}"


### PR DESCRIPTION
## Summary

- Replace all external `jq` calls in `fleet.sh` with `gh --jq` flag and bash arrays
- `fleet.sh` runs on the host machine where `jq` may not be installed (especially Windows)
- `gh` bundles its own Go-based jq implementation, so this eliminates the dependency while keeping the same issue-fetching, deduplication, and oldest-first sort logic

## Test plan

- [x] Run `fleet.sh` with multiple issues available and confirm correct assignment
- [x] Confirm oldest issues are picked first
- [x] Confirm deduplication works (assigned + agent-labelled issue spawns one container)
- [x] Confirm script runs on a host without `jq` installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)