### PR TITLE
chore: agent-loop sort order and stream-json output

### DIFF
--- a/.devcontainer/agent-loop.sh
+++ b/.devcontainer/agent-loop.sh
@@ -18,7 +18,8 @@ sync_state() {
 
 run_claude() {
     local prompt="$1"
-    timeout "$CLAUDE_TIMEOUT" claude --dangerously-skip-permissions --print "$prompt"
+    timeout "$CLAUDE_TIMEOUT" claude --dangerously-skip-permissions --print \
+        --output-format stream-json --verbose "$prompt"
 }
 
 load_prompt() {
@@ -154,12 +155,14 @@ Closes #${ISSUE_NUM}"
             # Self-select: assigned first, then labelled 'agent'
             ISSUE_JSON=$(gh issue list --assignee @me --state open \
                 --repo "$UPSTREAM_REPO" \
-                --json number,title --limit 1 2>/dev/null || echo "[]")
+                --json number,title --limit 1 \
+                --search "sort:created-asc" 2>/dev/null || echo "[]")
 
             if [ "$ISSUE_JSON" = "[]" ] || [ "$ISSUE_JSON" = "" ]; then
                 ISSUE_JSON=$(gh issue list --label agent --state open \
                     --repo "$UPSTREAM_REPO" \
-                    --json number,title --limit 1 2>/dev/null || echo "[]")
+                    --json number,title --limit 1 \
+                    --search "sort:created-asc" 2>/dev/null || echo "[]")
             fi
 
             ISSUE_NUM=$(echo "$ISSUE_JSON" | jq -r '.[0].number // empty')

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,3 +26,4 @@ HdrHistogram aims to be an extremely fast, low resource usage tool to collect la
 - Branch naming convention: `feat/`, `fix/`, `chore/` prefixes
 - PRs should target only one issue. An Issue may have multiple PRs to solve it in a managable way.
 - Before creating PRs, always have other agents test and review the code.
+- Avoid using `cd` or `git -C` when trying to perform tasks in the pwd (present working directory). It breaks the claude-code permission model forcing permission request that are unnessecary.


### PR DESCRIPTION
## Summary

- Add `sort:created-asc` to agent-loop.sh issue self-selection so agents pick the oldest issue first, matching fleet.sh behaviour
- Add `--output-format stream-json --verbose` to `run_claude()` for structured output
- Document `cd`/`git -C` avoidance guideline in CLAUDE.md

## Test plan

- [ ] Verify agent-loop picks oldest assigned issue first
- [ ] Verify stream-json output works correctly in container
- [ ] Review CLAUDE.md guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)