### PR TITLE
feat(#79): GetPercentileAtOrBelowValue

### DIFF
--- a/HdrHistogram.UnitTests/HistogramTestBase.cs
+++ b/HdrHistogram.UnitTests/HistogramTestBase.cs
@@ -480,6 +480,27 @@ namespace HdrHistogram.UnitTests
             histogram.GetPercentileAtOrBelowValue(500_000).Should().BeApproximately(50.0, 0.1);
         }
 
+        [Fact]
+        public void GetPercentileAtOrBelowValue_ZeroValue_WithPositiveRecordedValues_ReturnsZero()
+        {
+            var histogram = Create(DefaultHighestTrackableValue, DefaultSignificantFigures);
+            histogram.RecordValue(100);
+            histogram.RecordValue(1000);
+            // No recorded values are <= 0, so should return 0.0
+            histogram.GetPercentileAtOrBelowValue(0).Should().Be(0.0);
+        }
+
+        [Fact]
+        public void GetPercentileAtOrBelowValue_NegativeValue_ReturnsZero()
+        {
+            var histogram = Create(DefaultHighestTrackableValue, DefaultSignificantFigures);
+            histogram.RecordValue(100);
+            histogram.RecordValue(1000);
+            // Negative values are below any trackable range, so should return 0.0
+            histogram.GetPercentileAtOrBelowValue(-1).Should().Be(0.0);
+            histogram.GetPercentileAtOrBelowValue(long.MinValue).Should().Be(0.0);
+        }
+
         private void CreateAndAdd(HistogramBase source)
         {
             source.RecordValueWithCount(1, 100);

--- a/HdrHistogram/HistogramBase.cs
+++ b/HdrHistogram/HistogramBase.cs
@@ -392,11 +392,15 @@ namespace HdrHistogram
         /// This is the inverse of <see cref="GetValueAtPercentile"/>.
         /// All values within the same equivalent-value range map to the same percentile.
         /// </summary>
-        /// <param name="value">The value to find the percentile for</param>
+        /// <param name="value">The value to find the percentile for.</param>
         /// <returns>The percentage of recorded values that are less than or equal to <paramref name="value"/>, in the range <c>[0.0, 100.0]</c>. Returns <c>0.0</c> if no values have been recorded, or <c>100.0</c> if the value is at or above the highest trackable value.</returns>
         public double GetPercentileAtOrBelowValue(long value)
         {
             if (TotalCount == 0)
+            {
+                return 0.0;
+            }
+            if (value < 0)
             {
                 return 0.0;
             }


### PR DESCRIPTION
# Issue #79: GetPercentileOfValue

## Summary

The issue requests a method to answer: "Given a measurement value, what percentile does it fall under?"
This is the **inverse of `GetValueAtPercentile`**.
The API reference spec already names it `GetPercentileAtOrBelowValue(long value)` — that name is more precise and matches the Java HdrHistogram library's `percentileAtOrBelowValue`.
The method must be implemented in `HistogramBase` and exposed as a public instance method.

## What Needs to Change and Why

`HistogramBase` currently has `GetValueAtPercentile(double percentile) → long` but no inverse.
Users recording response times need to ask: "300ms is at what percentile?" without iterating the distribution themselves.
The spec (`spec/tech-standards/api-reference.md` line 132) already lists `GetPercentileAtOrBelowValue` as part of the public API surface, so this is a missing implementation.

## Affected Files (confirmed by exploration)

- `HdrHistogram/HistogramBase.cs` — add `GetPercentileAtOrBelowValue(long value)` method (near `GetValueAtPercentile`, around line 388)
- `HdrHistogram.UnitTests/HistogramTestBase.cs` — add shared tests covering all histogram types
- `spec/tech-standards/api-reference.md` — no change needed; method is already listed

## Acceptance Criteria

1. A public method `double GetPercentileAtOrBelowValue(long value)` exists on `HistogramBase`.
2. Returns a value in the range `[0.0, 100.0]`.
3. For a recorded value `v`, `GetPercentileAtOrBelowValue(v)` returns the percentage of all recorded values that are `<= v` (using the histogram's equivalent-value range semantics).
4. Returns `100.0` when `value >= HighestTrackableValue` or when `value` is beyond the tracked range.
5. Returns `0.0` when `TotalCount == 0` (empty histogram).
6. Consistent with `GetValueAtPercentile`: `GetValueAtPercentile(GetPercentileAtOrBelowValue(v))` should equal the highest equivalent value of the bucket containing `v` (within histogram resolution).
7. Monotonic: for `v1 < v2`, `GetPercentileAtOrBelowValue(v1) <= GetPercentileAtOrBelowValue(v2)`.

## Algorithm

Mirrors the bucket-traversal loop in `GetValueAtPercentile` but in the forward direction:

1. Compute `targetBucketIndex = GetBucketIndex(value)` and `targetSubBucketIndex = GetSubBucketIndex(value, targetBucketIndex)`.
2. If `targetBucketIndex >= BucketCount`, return `100.0`.
3. Accumulate counts for all sub-buckets up to and including `(targetBucketIndex, targetSubBucketIndex)`.
4. Return `(100.0 * countAtValue) / TotalCount`.
5. Guard: if `TotalCount == 0`, return `0.0`.

## Test Strategy

Add tests to `HistogramTestBase` (runs across all histogram types via the abstract factory):

- **Basic percentile**: record a known set of values; assert `GetPercentileAtOrBelowValue` returns the expected percentage.
- **Round-trip consistency**: for a set of recorded values, assert `GetValueAtPercentile(GetPercentileAtOrBelowValue(v))` equals `HighestEquivalentValue(LowestEquivalentValue(v))`.
- **Empty histogram**: `TotalCount == 0` returns `0.0`.
- **At maximum**: value at or above `HighestTrackableValue` returns `100.0`.
- **Monotonicity**: verify that queried percentiles are non-decreasing for increasing input values.
- **Single value**: histogram with one recorded value; any query `>= that value` returns `100.0`, any query `< that value` returns `0.0`.
- **Boundary**: value exactly at `LowestTrackableValue` returns `(count_at_lowest / TotalCount) * 100`.

Tests should use `FluentAssertions` with appropriate tolerance for floating-point comparisons (e.g., `BeApproximately(..., precision: 0.1)`).

## Risks and Open Questions

- **Naming**: The issue title says `GetPercentileOfValue`; the spec says `GetPercentileAtOrBelowValue`.
  Use `GetPercentileAtOrBelowValue` to match the spec and Java library.
- **Values outside tracked range**: The method should not throw; return `100.0` for values above `HighestTrackableValue` (consistent with Java implementation).
- **Equivalent-value semantics**: The query value is mapped to a bucket via `GetBucketIndex`/`GetSubBucketIndex`, matching the same resolution logic used throughout `HistogramBase`.
  All values within the same equivalent range map to the same percentile.
- **Thread safety**: The method only reads counts; concurrent histograms (`LongConcurrentHistogram`, `IntConcurrentHistogram`) inherit the same implementation and their atomic reads ensure a consistent (if momentarily stale) snapshot.

<details>
<summary>Task breakdown</summary>

# Task Checklist: Issue #79 — `GetPercentileAtOrBelowValue`

Cross-reference: every acceptance criterion in `brief.md` is covered by at least one task below (see criterion labels in parentheses).

---

## Implementation

- [x] **`HdrHistogram/HistogramBase.cs`** — Add `GetPercentileAtOrBelowValue(long value)` as a public instance method returning `double`, placed directly after `GetValueAtPercentile` (around line 388).
  - Algorithm (mirrors the bucket-traversal loop of `GetValueAtPercentile` in the forward direction):
    1. Guard: if `TotalCount == 0`, return `0.0`. *(criterion 5)*
    2. Compute `bucketIndex = GetBucketIndex(value)` and `subBucketIndex = GetSubBucketIndex(value, bucketIndex)`.
    3. If `bucketIndex >= BucketCount`, return `100.0`. *(criterion 4)*
    4. Traverse from bucket 0 / sub-bucket 0 through `(bucketIndex, subBucketIndex)` inclusive, accumulating counts via `GetCountAt(i, j)`. Use the same loop structure as `GetValueAtPercentile`: first bucket starts at `j = 0`; subsequent buckets start at `j = SubBucketHalfCount`. *(criterion 3)*
    5. Return `(100.0 * runningCount) / TotalCount`, clamped to `[0.0, 100.0]`. *(criteria 1, 2)*
  - Verifiable: method appears in `HistogramBase`, compiles without error, and all tests below pass.

- [x] **`HdrHistogram/HistogramBase.cs`** — Add XML doc comment for `GetPercentileAtOrBelowValue` following the existing style (summary, `<param>`, `<returns>`).
  - Must describe: the method is the inverse of `GetValueAtPercentile`; the return range `[0.0, 100.0]`; the equivalent-value-range semantics.
  - Verifiable: `dotnet build` produces no XML doc warnings for the new method.

---

## Unit Tests

All tests go in **`HdrHistogram.UnitTests/HistogramTestBase.cs`** as `[Fact]` methods on the abstract base class, so they run for `ShortHistogram`, `IntHistogram`, and `LongHistogram` automatically.
Use `FluentAssertions` and the existing `Create(highestTrackableValue, significantFigures)` / `Create(lowestTrackableValue, highestTrackableValue, significantFigures)` factory helpers.
Floating-point comparisons must use `.BeApproximately(..., precision: 0.1)` unless an exact value is expected.

- [x] **Empty histogram returns 0.0** *(criterion 5)*
  - Create a histogram with no recorded values.
  - Assert `histogram.GetPercentileAtOrBelowValue(TestValueLevel).Should().Be(0.0)`.
  - Verifiable: test is green for all three histogram word sizes.

- [x] **Value at or above `HighestTrackableValue` returns 100.0** *(criterion 4)*
  - Create a histogram, record at least one value.
  - Assert `histogram.GetPercentileAtOrBelowValue(DefaultHighestTrackableValue).Should().Be(100.0)`.
  - Also assert for a value beyond range: `histogram.GetPercentileAtOrBelowValue(long.MaxValue / 2).Should().Be(100.0)`.
  - Verifiable: test is green; no exception is thrown.

- [x] **Basic percentile — known value set** *(criterion 3)*
  - Record values `1` through `100` (one each), so `TotalCount == 100`.
  - Assert `GetPercentileAtOrBelowValue(50)` is approximately `50.0` (±0.1).
  - Assert `GetPercentileAtOrBelowValue(100)` is approximately `100.0` (±0.1).
  - Assert `GetPercentileAtOrBelowValue(1)` is approximately `1.0` (±0.1).
  - Verifiable: test is green for all three histogram word sizes.

- [x] **Return value is always in range `[0.0, 100.0]`** *(criterion 2)*
  - Record a known set of values.
  - For a range of query values (including 0, a recorded value, and `HighestTrackableValue`), assert each result `.Should().BeInRange(0.0, 100.0)`.
  - Verifiable: test is green for all three histogram word sizes.

- [x] **Round-trip consistency with `GetValueAtPercentile`** *(criterion 6)*
  - Record values `1`, `10`, `100`, `1000`.
  - For each recorded value `v`, compute `p = histogram.GetPercentileAtOrBelowValue(v)`.
  - Assert `histogram.GetValueAtPercentile(p)` equals `histogram.HighestEquivalentValue(histogram.LowestEquivalentValue(v))`.
  - Verifiable: test is green; demonstrates the inverse relationship holds within histogram resolution.

- [x] **Monotonicity — non-decreasing percentiles for increasing values** *(criterion 7)*
  - Record values `1`, `50`, `100`, `500`, `1000`.
  - Query percentiles for `1, 10, 50, 100, 500, 1000, 5000` in order.
  - Assert each successive result is `>=` the previous one.
  - Verifiable: test is green for all three histogram word sizes.

- [x] **Single recorded value — queries below return 0.0, queries at or above return 100.0** *(criteria 3, 4, 5)*
  - Create a histogram, record value `TestValueLevel` (= 4) once.
  - Assert `GetPercentileAtOrBelowValue(TestValueLevel - 1).Should().Be(0.0)` (value below the recorded value).
  - Assert `GetPercentileAtOrBelowValue(TestValueLevel).Should().Be(100.0)` (value equals the recorded value).
  - Assert `GetPercentileAtOrBelowValue(TestValueLevel + 1000).Should().Be(100.0)` (value above the recorded value).
  - Verifiable: test is green for all three histogram word sizes.

- [x] **Boundary — query at `LowestTrackableValue`** *(criterion 3)*
  - Create a histogram with `lowestTrackableValue = 1`.
  - Record value `1` once and value `1000` once (`TotalCount == 2`).
  - Assert `GetPercentileAtOrBelowValue(1)` is approximately `50.0` (±0.1) — one of two values is `<= 1`.
  - Verifiable: test is green for all three histogram word sizes.

---

## Acceptance Criterion Coverage Matrix

| Criterion | Covered by task(s) |
|-----------|-------------------|
| 1. Public method `double GetPercentileAtOrBelowValue(long value)` on `HistogramBase` | Implementation task (add method) |
| 2. Return value in `[0.0, 100.0]` | Implementation (clamp); test "Return value is always in range" |
| 3. Returns % of values `<= v` using equivalent-value semantics | Implementation (algorithm step 4); tests: basic percentile, single value, boundary |
| 4. Returns `100.0` when `value >= HighestTrackableValue` or beyond range | Implementation (step 3); tests: at-maximum, single value (above) |
| 5. Returns `0.0` when `TotalCount == 0` | Implementation (step 1); test: empty histogram |
| 6. Round-trip: `GetValueAtPercentile(GetPercentileAtOrBelowValue(v))` equals highest equivalent value of bucket | Test: round-trip consistency |
| 7. Monotonic for increasing input values | Test: monotonicity |

</details>

Closes #79