### PR TITLE
chore: pass issue number argument to devcontainer

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(realpath "$SCRIPT_DIR/..")"
+ISSUE_NUMBER="${1:-}"
 
 # Load env
 if [ -f "$REPO_ROOT/autonomous/.env" ]; then
@@ -22,5 +23,6 @@ docker run --rm \
     --memory=4g \
     --cpus=2 \
     --env-file "$REPO_ROOT/autonomous/.env" \
+    ${ISSUE_NUMBER:+-e ISSUE_NUMBER="$ISSUE_NUMBER"} \
     -v nuget-cache:/home/agent/.nuget/packages \
     hdrhistogram-agent


### PR DESCRIPTION
## Summary

- Allow `run.sh` to accept an optional issue number as a CLI argument
- Forward the issue number as the `ISSUE_NUMBER` environment variable to the Docker container

## Test plan

- [ ] Run `./run.sh` without arguments — container starts without `ISSUE_NUMBER` set
- [ ] Run `./run.sh 42` — container starts with `ISSUE_NUMBER=42`

🤖 Generated with [Claude Code](https://claude.com/claude-code)