### PR TITLE
ci(#119): install .NET 9.0 and 10.0 SDKs in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
           cache: true
           cache-dependency-path: '**/*.csproj'
 


### PR DESCRIPTION
## Summary

- Updates `.github/workflows/ci.yml` to install .NET SDK 8.0.x, 9.0.x, and 10.0.x using a single `setup-dotnet` step with a multi-line `dotnet-version` scalar
- This is the missing workflow change from #150, which the PR author's PAT lacked `workflow` scope to push

## Context

This is a stacked PR on top of #150 (`feat(#119): Add support for all currently supported .NET frameworks`).
PR #150 contains all the project file, devcontainer, and spec changes but could not modify `.github/workflows/` due to PAT permission restrictions.

**Merge #150 first**, then this PR's diff will reduce to just the CI workflow change.

## Test plan

- [ ] CI pipeline installs all three SDK versions and builds/tests successfully against net8.0, net9.0, and net10.0

Closes the remaining acceptance criterion from #119 (AC-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)