### PR TITLE
ci(#117): add dotnet format check to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
           cache-dependency-path: '**/*.csproj'
 
       - run: dotnet restore
+      - name: Check code formatting
+        run: dotnet format --verify-no-changes --verbosity diagnostic
       - run: dotnet build -c Release --no-restore /p:Version=${{ env.SEMVER }}
       - run: dotnet test ./HdrHistogram.UnitTests/HdrHistogram.UnitTests.csproj --no-build -c Release
       - run: dotnet pack ./HdrHistogram/HdrHistogram.csproj -c Release --no-build --include-symbols --no-restore /p:Version=${{ env.SEMVER }}


### PR DESCRIPTION
## Summary

- Adds a `dotnet format --verify-no-changes --verbosity diagnostic` step to the CI workflow between `dotnet restore` and `dotnet build`.
- PRs that violate `.editorconfig` formatting rules will fail fast with clear diagnostic output naming the offending files.

## Dependency

This PR is stacked on #152 which provides the nullable warning fixes needed for the format check to pass cleanly.
Merge #152 first, then this PR.

## Changes

- `.github/workflows/ci.yml` — single new step inserted after restore, before build.

## Test plan

- [ ] Confirm `dotnet format --verify-no-changes` step appears in the GitHub Actions log.
- [ ] Confirm CI passes (after #152 nullable fixes are merged).
- [ ] Optionally introduce a deliberate formatting violation on a throwaway branch to verify the step fails with diagnostic output.

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)