### PR TITLE
feat: add sync-git skill and script

### DIFF
--- a/.claude/skills/sync-git/SKILL.md
+++ b/.claude/skills/sync-git/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: sync-git
+description: Sync local repo with upstream, clean up branches and remotes
+disable-model-invocation: true
+allowed-tools: Bash
+---
+
+Run `bash scripts/synch-git.sh` and report the output to the user.

--- a/scripts/synch-git.sh
+++ b/scripts/synch-git.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== Syncing main with upstream ==="
+git fetch upstream main
+git checkout main
+git merge upstream/main --ff-only
+
+echo ""
+echo "=== Pruning stale remote-tracking references ==="
+git fetch origin --prune
+git fetch upstream --prune
+
+echo ""
+echo "=== Deleting local branches merged into main ==="
+merged=$(git branch --merged main | grep -v '^\*\|main' || true)
+if [ -n "$merged" ]; then
+  echo "$merged" | xargs git branch -d
+else
+  echo "No merged branches to delete."
+fi
+
+echo ""
+echo "=== Done ==="
+git branch


### PR DESCRIPTION
## Summary

- Add `/sync-git` Claude Code skill that syncs the local repo with upstream
- Add `scripts/synch-git.sh` bash script that fetches upstream main, prunes stale remote-tracking refs, and deletes local branches already merged into main

## Test plan

- [ ] Run `/sync-git` skill and verify it syncs with upstream
- [ ] Verify stale remote-tracking refs are pruned
- [ ] Verify merged local branches are deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)