### PR TITLE
fix: correct autonomous Docker base image to existing tag

### DIFF
--- a/autonomous/Dockerfile
+++ b/autonomous/Dockerfile
@@ -2,7 +2,7 @@
 # HdrHistogram.NET Agent Container
 # .NET SDK + Claude Code + gh CLI + firewall
 # =============================================================================
-FROM mcr.microsoft.com/dotnet/sdk:10.0-bookworm-slim
+FROM mcr.microsoft.com/dotnet/sdk:10.0-noble
 RUN dotnet_version=8.0 \
     && curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin \
        --runtime dotnet --channel $dotnet_version --install-dir /usr/share/dotnet \


### PR DESCRIPTION
## Summary

- Replace `mcr.microsoft.com/dotnet/sdk:10.0-bookworm-slim` (does not exist) with `10.0-noble`
- .NET 10 SDK images use Ubuntu Noble (24.04), not Debian Bookworm

## Test plan

- [ ] `docker build autonomous/` succeeds (base image pulls correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)