### PR TITLE
fix: ensure agent loop continues after Claude timeout or API errors

### DIFF
--- a/autonomous/agent-loop.sh
+++ b/autonomous/agent-loop.sh
@@ -57,12 +57,15 @@ sync_state() {
     fi
 }
 
-CLAUDE_RC=0
-
 run_claude() {
     local prompt="$1"
+    local rc=0
     timeout "$CLAUDE_TIMEOUT" claude --dangerously-skip-permissions --print \
-        --output-format stream-json --verbose "$prompt" || CLAUDE_RC=$?
+        --output-format stream-json --verbose "$prompt" || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "WARNING: claude exited with code $rc" >&2
+    fi
+    return "$rc"
 }
 
 load_prompt() {
@@ -197,25 +200,25 @@ EOF
 
     execute-tasks)
         ISSUE_NUM=$(get_issue_num)
-        run_claude "$(load_prompt execute-tasks)"
+        run_claude "$(load_prompt execute-tasks)" || true
         sync_state "feat(#${ISSUE_NUM}): implement tasks"
         ;;
 
     create-tasks)
         ISSUE_NUM=$(get_issue_num)
-        run_claude "$(load_prompt create-tasks)"
+        run_claude "$(load_prompt create-tasks)" || true
         sync_state "plan(#${ISSUE_NUM}): create task breakdown"
         ;;
 
     apply-review)
         ISSUE_NUM=$(get_issue_num)
-        run_claude "$(load_prompt apply-review)"
+        run_claude "$(load_prompt apply-review)" || true
         sync_state "plan(#${ISSUE_NUM}): apply brief review feedback"
         ;;
 
     review-brief)
         ISSUE_NUM=$(get_issue_num)
-        run_claude "$(load_prompt review-brief)"
+        run_claude "$(load_prompt review-brief)" || true
         sync_state "plan(#${ISSUE_NUM}): review brief"
         ;;
 
@@ -269,7 +272,7 @@ EOF
                 PROMPT=$(load_prompt pick-issue)
                 PROMPT="${PROMPT//\{\{ISSUE_BODY\}\}/$ISSUE_BODY}"
 
-                run_claude "$PROMPT"
+                run_claude "$PROMPT" || true
                 sync_state "plan(#${ISSUE_NUM}): initial brief from issue"
             fi
         else
@@ -285,10 +288,8 @@ EOF
             PROMPT=$(load_prompt pick-issue)
             PROMPT="${PROMPT//\{\{ISSUE_BODY\}\}/$ISSUE_BODY}"
 
-            run_claude "$PROMPT"
+            run_claude "$PROMPT" || true
             sync_state "plan(#${ISSUE_NUM}): initial brief from issue"
         fi
         ;;
 esac
-
-exit $CLAUDE_RC

--- a/autonomous/entrypoint.sh
+++ b/autonomous/entrypoint.sh
@@ -39,11 +39,8 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
     EXIT_CODE=0
     bash /usr/local/bin/agent-loop.sh || EXIT_CODE=$?
 
-    if [ "$EXIT_CODE" -ne 0 ] && [ "$EXIT_CODE" -ne 124 ]; then
-        echo "Iteration $i failed with exit code $EXIT_CODE"
-        break
-    elif [ "$EXIT_CODE" -eq 124 ]; then
-        echo "Iteration $i timed out (exit code 124), continuing..."
+    if [ "$EXIT_CODE" -ne 0 ]; then
+        echo "Iteration $i exited with code $EXIT_CODE, continuing to next state..."
     fi
 
     # Done?


### PR DESCRIPTION
## Summary

- Agent loop would halt when Claude exited with a non-zero, non-124 code, preventing the state machine from advancing to `create-pr` after a successful `execute-tasks` where sync_state had already committed and pushed
- `run_claude` now returns its exit code directly; callers use `|| true` so `sync_state` always runs
- `entrypoint.sh` logs non-zero exits as warnings and continues iterating instead of breaking

## Root cause

Issue #141's container run completed all implementation work and benchmarks, but a sub-agent API timeout cascaded: `CLAUDE_RC` was set to non-zero, `exit $CLAUDE_RC` returned that to `entrypoint.sh`, which broke the loop before the next iteration could reach the `create-pr` state (which is pure shell — no Claude needed).

## Test plan

- [ ] Run `./scripts/run.sh` with a short `TIMEOUT_SECONDS` to trigger a Claude timeout
- [ ] Verify the loop continues to the next state after timeout
- [ ] Verify `create-pr` state still executes after a timed-out `execute-tasks`

🤖 Generated with [Claude Code](https://claude.com/claude-code)