### PR TITLE
fix: exclude worktree branches from synch-git cleanup

### DIFF
--- a/scripts/synch-git.sh
+++ b/scripts/synch-git.sh
@@ -13,7 +13,7 @@ git fetch upstream --prune
 
 echo ""
 echo "=== Deleting local branches merged into main ==="
-merged=$(git branch --merged main | grep -v '^\*\|main' || true)
+merged=$(git branch --merged main | grep -v '^\*\|^+\|main' || true)
 if [ -n "$merged" ]; then
   echo "$merged" | xargs git branch -d
 else


### PR DESCRIPTION
## Summary

- Fix `scripts/synch-git.sh` to filter out worktree branches (prefixed with `+`) when deleting merged branches, preventing errors when worktrees are active.

## Test plan

- [ ] Run `synch-git.sh` with an active worktree and verify the worktree branch is not targeted for deletion
- [ ] Run `synch-git.sh` without worktrees and verify merged branches are still cleaned up normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)